### PR TITLE
Fix drawer close

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
 	"name": "o-header-services",
 	"dependencies": {
 		"o-assets": "^3.0.2",
-		"o-header": "^6.4.0",
+		"o-header": "^6.6.1",
 		"o-colors": "^3.5.0",
 		"o-grid": "^4.2.0",
 		"o-typography": "^4.0.0"

--- a/demos/src/no-navigation.mustache
+++ b/demos/src/no-navigation.mustache
@@ -42,7 +42,7 @@
 		<div class="o-header__drawer-tools">
 			<span>Tool or Service name</span>
 			<button type="button" class="o-header__drawer-tools-close" aria-controls="o-header-drawer">
-				<span class="o-header_visually-hidden">Close</span>
+				<span class="o-header__visually-hidden">Close</span>
 			</button>
 		</div>
 		<nav class="o-header__drawer-menu o-header__drawer-menu--user" role="navigation" aria-label="User navigation">

--- a/demos/src/one-navigation.mustache
+++ b/demos/src/one-navigation.mustache
@@ -44,7 +44,7 @@
 		<div class="o-header__drawer-tools">
 			<span>Tool or Service name</span>
 			<button type="button" class="o-header__drawer-tools-close" aria-controls="o-header-drawer">
-				<span class="o-header_visually-hidden">Close</span>
+				<span class="o-header__visually-hidden">Close</span>
 			</button>
 		</div>
 		<nav class="o-header__drawer-menu o-header__drawer-menu--primary" role="navigation" aria-label="Primary navigation">

--- a/src/scss/_drawer.scss
+++ b/src/scss/_drawer.scss
@@ -2,6 +2,10 @@
 
 	@include oHeaderDrawer();
 
+	.o-header__visually-hidden {
+		@include oHeaderVisuallyHidden;
+	}
+
 	// Override some styles here for the drawer
 	.o-header-drawer--services {
 


### PR DESCRIPTION
Bumps the version of `o-header` which adds the visually hidden mixin and implements the class here. Also corrects a typo in the classnames for demos.