### PR TITLE
A11y and link in product title

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The simplest header, appropriate for single page applications with no navigation
 	<div class='o-header-services__top o-header-services__container'>
 		<div class='o-header-services__ftlogo'></div>
 		<div class='o-header-services__title'>
-			<h1 class='o-header-services__product-name'>Tool or Service name</h1>
+			<h1 class='o-header-services__product-name'><a href='/'>Tool or Service name</a></h1>
 			<span class='o-header-subrand__product-tagline '>Tagline to explain the product here</span>
 		</div>
 	</div>
@@ -63,7 +63,7 @@ To add a theme to the header, add the appropriate class to a wrapping element. F
 	<div class='o-header-services__top o-header-services__container'>
 		<div class='o-header-services__ftlogo'></div>
 		<div class='o-header-services__title'>
-			<h1 class='o-header-services__product-name'>Tool or Service name</h1>
+			<h1 class='o-header-services__product-name'><a href='/'>Tool or Service name</a></h1>
 			<span class='o-header-subrand__product-tagline '>Tagline to explain the product here</span>
 		</div>
 	</div>
@@ -84,11 +84,11 @@ To add support for related content, add the following to your markup:
 	<div class='o-header-services__top'>
 		<div class='o-header-services__container'>
 +			<div class='o--if-js o-header-services__hamburger'>
-+				<a class='o-header-services__hamburger-icon' href="#o-header-drawer"	aria-controls="o-header-drawer"></a>
++				<a class='o-header-services__hamburger-icon' href="#o-header-drawer"	aria-controls="o-header-drawer"><span class="o-header__visually-hidden">Menu</span></a>
 +			</div>
 			<div class='o-header-services__ftlogo'></div>
 			<div class='o-header-services__title'>
-				<h1 class='o-header-services__product-name'>Tool or Service name</h1><span class='o-header-subrand__product-tagline '>Tagline to explain the product here</span>
+				<h1 class='o-header-services__product-name'><a href=''>Tool or Service name</a></h1><span class='o-header-subrand__product-tagline '>Tagline to explain the product here</span>
 			</div>
 			<div class='o-header-services__related-content'>
 				<a href='#'>XXXX</a>
@@ -118,11 +118,11 @@ This requires the drawer code, as seen above, and the following addition:
 	<div class='o-header-services__top'>
 		<div class='o-header-services__container'>
 			<div class='o--if-js o-header-services__hamburger'>
-				<a class='o-header-services__hamburger-icon' href="#o-header-drawer"	aria-controls="o-header-drawer"></a>
+				<a class='o-header-services__hamburger-icon' href="#o-header-drawer"	aria-controls="o-header-drawer"><span class="o-header__visually-hidden">Menu</span></a>
 			</div>
 			<div class='o-header-services__ftlogo'></div>
 			<div class='o-header-services__title'>
-				<h1 class='o-header-services__product-name'>Tool or Service name</h1><span class='o-header-subrand__product-tagline '>Tagline to explain the product here</span>
+				<h1 class='o-header-services__product-name'><a href=''>Tool or Service name</a></h1><span class='o-header-subrand__product-tagline '>Tagline to explain the product here</span>
 			</div>
 			<div class='o-header-services__related-content'>
 				<a href='#'>XXXX</a>
@@ -149,7 +149,7 @@ This requires the drawer code, as seen above, and the following addition:
 ## Migration guide
 ## Trouble shooting
 ### Contact info
-Please raise an issue, or Internal FT users can contact us via #ft-origami in Slack. 
+Please raise an issue, or Internal FT users can contact us via #ft-origami in Slack.
 
 ## License
 

--- a/demos/src/no-navigation.mustache
+++ b/demos/src/no-navigation.mustache
@@ -24,11 +24,11 @@
 	<div class='o-header-services__top'>
 		<div class='o-header-services__container'>
 			<div class='o--if-js o-header-services__hamburger'>
-				<a class='o-header-services__hamburger-icon' href="#o-header-drawer"	aria-controls="o-header-drawer"></a>
+				<a class='o-header-services__hamburger-icon' href="#o-header-drawer"	aria-controls="o-header-drawer"><span class="o-header__visually-hidden">Menu</span></a>
 			</div>
 			<div class='o-header-services__ftlogo'></div>
 			<div class='o-header-services__title'>
-				<h1 class='o-header-services__product-name'>Tool or Service name</h1><span class='o-header-subrand__product-tagline '>Tagline to explain the product here</span>
+				<h1 class='o-header-services__product-name'><a href="/">Tool or Service name</a></h1><span class='o-header-subrand__product-tagline '>Tagline to explain the product here</span>
 			</div>
 			<div class='o-header-services__related-content'>
 				<a href='#'>XXXX</a>

--- a/demos/src/one-navigation.mustache
+++ b/demos/src/one-navigation.mustache
@@ -1,11 +1,11 @@
 <header class='o-header-services' data-o-component='o-header'>
 	<div class='o-header-services__top o-header-services__container'>
 		<div class='o-header-services__hamburger'>
-			<a class='o-header-services__hamburger-icon' href="#o-header-drawer"	aria-controls="o-header-drawer"></a>
+			<a class='o-header-services__hamburger-icon' href="#o-header-drawer"	aria-controls="o-header-drawer"><span class="o-header__visually-hidden">Menu</span></a>
 		</div>
 		<div class='o-header-services__ftlogo'></div>
 		<div class='o-header-services__title'>
-			<h1 class='o-header-services__product-name'>Tool or Service name</h1><span class='o-header-subrand__product-tagline'>Tagline to explain the product here</span>
+			<h1 class='o-header-services__product-name'><a href="/">Tool or Service name</a></h1><span class='o-header-subrand__product-tagline'>Tagline to explain the product here</span>
 		</div>
 		<div class='o-header-services__related-content'>
 			<a class='o-header-services__related-content-link' href='#'>XXXX</a>

--- a/demos/src/themes.mustache
+++ b/demos/src/themes.mustache
@@ -5,7 +5,7 @@ This component is themable. The current available themes are B2B and B2C. If you
 	<div class='o-header-services__top o-header-services__container'>
 		<div class='o-header-services__ftlogo'></div>
 		<div class='o-header-services__title'>
-			<h1 class='o-header-services__product-name'>B2C Tool or Service name</h1><span class='o-header-subrand__product-tagline '>Tagline to explain the product here</span>
+			<h1 class='o-header-services__product-name'><a href="/">B2C Tool or Service name</a></h1><span class='o-header-subrand__product-tagline '>Tagline to explain the product here</span>
 		</div>
 	</div>
 </header>
@@ -15,7 +15,7 @@ This component is themable. The current available themes are B2B and B2C. If you
 	<div class='o-header-services__top o-header-services__container'>
 		<div class='o-header-services__ftlogo'></div>
 		<div class='o-header-services__title'>
-			<h1 class='o-header-services__product-name'>B2B Tool or Service name</h1><span class='o-header-subrand__product-tagline '>Tagline to explain the product here</span>
+			<h1 class='o-header-services__product-name'><a href="/">B2B Tool or Service name</a></h1><span class='o-header-subrand__product-tagline '>Tagline to explain the product here</span>
 		</div>
 	</div>
 </header>

--- a/demos/src/very-simple.mustache
+++ b/demos/src/very-simple.mustache
@@ -24,7 +24,7 @@
 	<div class='o-header-services__top o-header-services__container'>
 		<div class='o-header-services__ftlogo'></div>
 		<div class='o-header-services__title'>
-			<h1 class='o-header-services__product-name'>Tool or Service name</h1><span class='o-header-subrand__product-tagline '>Tagline to explain the product here</span>
+			<h1 class='o-header-services__product-name'><a href="/">Tool or Service name</a></h1><span class='o-header-subrand__product-tagline '>Tagline to explain the product here</span>
 		</div>
 	</div>
 </header>

--- a/src/scss/_top.scss
+++ b/src/scss/_top.scss
@@ -51,6 +51,7 @@
 		padding: $_o-header-services-padding-y $_o-header-services-padding-x;
 		display: inline-block;
 		float: left;
+
 		@include oGridRespondTo($until: M) {
 			margin: 0;
 		}
@@ -70,6 +71,11 @@
 		@include oGridRespondTo($until: M) {
 			@include oTypographySans(m);
 			font-weight: 600;
+		}
+
+		a {
+			color: inherit;
+			text-decoration: none;
 		}
 	}
 


### PR DESCRIPTION
Adds text to the drawer button for accessibility (visually hidden).

Adds styles to allow for links in the product title tag and updates examples and readme.