### PR TITLE
update logo url

### DIFF
--- a/src/scss/_top.scss
+++ b/src/scss/_top.scss
@@ -13,7 +13,7 @@
 		margin: 8px 8px 8px 0;
 		float: left;
 		display: inline-block;
-		background-image: url($logo);
+		background-image: url('https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1:#{$logo}?source=o-header-services&format=svg&width=55');
 		background-repeat: no-repeat;
 		background-size: contain;
 		background-position: 0;

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -7,4 +7,4 @@ $_o-header-services-top-bar-y: 56px;
 $_o-header-services-top-bar-y-small: 44px;
 $_o-header-services-primary-nav-y: 36px;
 
-$o-header-services-default-logo: 'https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1:#{_oHeaderServicesGet('logo')}?source=o-header-services&format=svg&width=55';
+$o-header-services-default-logo: _oHeaderServicesGet('logo');


### PR DESCRIPTION
This enforces logos from the ftlogo image set to be used, and allows more succint logo names in products using the `oHeaderServiceTop` mixin (e.g. `o-layout`)