### PR TITLE
Only display the draw when "data-o-header-drawer--js" has been added by `o-header` JS.

### DIFF
--- a/src/scss/_drawer.scss
+++ b/src/scss/_drawer.scss
@@ -1,4 +1,12 @@
 @mixin oHeaderServicesDrawer() {
+	// :mask: Unlike o-header, the README and demos say to include ".o--if-js" on the draw.
+	// ".core .o--if-js" may be repalced with ".enhanced .o--if-js" before "data-o-header-drawer--js" is added.
+	// This causes a flash where the draw is rendered before being positioned.
+	// So, only display the draw when "data-o-header-drawer--js" has been added by o-header.
+	.enhanced .o--if-js.o-header__drawer:not([data-o-header-drawer--js]) {
+		display: none;
+	}
+
 	@include oHeaderDrawer();
 
 	.o-header__visually-hidden {

--- a/src/scss/_drawer.scss
+++ b/src/scss/_drawer.scss
@@ -1,6 +1,6 @@
 @mixin oHeaderServicesDrawer() {
 	// :mask: Unlike o-header, the README and demos say to include ".o--if-js" on the draw.
-span class="pl-c"> 	// ".core .o--if-js" may be replaced with ".enhanced .o--if-js" before "data-o-header-drawer--js" is added.
+	// ".core .o--if-js" may be replaced with ".enhanced .o--if-js" before "data-o-header-drawer--js" is added.
 	// This causes a flash where the draw is rendered before being positioned.
 	// So, only display the draw when "data-o-header-drawer--js" has been added by o-header.
 	.enhanced .o--if-js.o-header__drawer:not([data-o-header-drawer--js]) {

--- a/src/scss/_drawer.scss
+++ b/src/scss/_drawer.scss
@@ -1,6 +1,6 @@
 @mixin oHeaderServicesDrawer() {
 	// :mask: Unlike o-header, the README and demos say to include ".o--if-js" on the draw.
-	// ".core .o--if-js" may be repalced with ".enhanced .o--if-js" before "data-o-header-drawer--js" is added.
+span class="pl-c"> 	// ".core .o--if-js" may be replaced with ".enhanced .o--if-js" before "data-o-header-drawer--js" is added.
 	// This causes a flash where the draw is rendered before being positioned.
 	// So, only display the draw when "data-o-header-drawer--js" has been added by o-header.
 	.enhanced .o--if-js.o-header__drawer:not([data-o-header-drawer--js]) {


### PR DESCRIPTION
:mask: Unlike `o-header`, the README and demos for `o-header-serivces` say to include ".o--if-js" on the draw. However ".core .o--if-js" may be repalced with ".enhanced .o--if-js" before "data-o-header-drawer--js" is added. This causes a flash where the draw is rendered before being positioned. So, only display the draw when "data-o-header-drawer--js" has been added by o-header.

I believe this is what causes the flash when navigating  `o-layout` sites *:warning: gif flashes*:

...
...
...
...
...
...
...
...
...
...
...
...
...
...
...
...
...
...
...
...
...
...
...
...
...
...
...
...
...
...
...
...
...
...
...
...

![kapture 2018-10-16 at 17 51 12](https://user-images.githubusercontent.com/10405691/47033219-2a3b4280-d16c-11e8-85c3-fffa7f84891e.gif)
