### PR TITLE
A11y

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The simplest header, appropriate for single page applications with no navigation
 
 ```
 <header class='o-header-services' data-o-component='o-header-services'>
-	<div class='o-header-services__top o-header-services__container'>
+	<div class='o-header-services__top'>
 		<div class='o-header-services__logo'></div>
 		<div class='o-header-services__title'>
 			<h1 class='o-header-services__product-name'><a href='/'>Tool or Service name</a></h1>
@@ -58,7 +58,7 @@ The simplest header, appropriate for single page applications with no navigation
 ```diff
 +<header class='o-header-services o-header-services--b2b' data-o-component='o-header'>
 -<header class='o-header-services' data-o-component='o-header'>
-	<div class='o-header-services__top o-header-services__container'>
+	<div class='o-header-services__top'>
 		<div class='o-header-services__logo'></div>
 		<div class='o-header-services__title'>
 			<h1 class='o-header-services__product-name'><a href='/'>Tool or Service name</a></h1>
@@ -82,23 +82,23 @@ To add support for related content, add the following to your markup:
 ```diff
 <header class='o-header-services' data-o-component='o-header'>
 	<div class='o-header-services__top'>
-		<div class='o-header-services__container'>
-+			<div class='o-header-services__hamburger'>
-+				<a class='o-header-services__hamburger-icon' href="#""><span class="o-header-services__visually-hidden">Menu</span></a>
-+			</div>
-			<div class='o-header-services__logo'></div>
-			<div class='o-header-services__title'>
-				<h1 class='o-header-services__product-name'><a href=''>Tool or Service name</a></h1><span class='o-header-subrand__product-tagline '>Tagline to explain the product here</span>
-			</div>
-+			<ul class="o-header-services__related-content">
-+				<li class="o-header-services__related-content-list-item">
-+					<a class="o-header-services__related-content-link" href="#">XXXX</a>
-+				</li>
-+				<li class="o-header-services__related-content-list-item">
-+					<a class="o-header-services__related-content-link" href="#">Sign in</a>
-+				</li>
-+			</ul>
++		<div class='o-header-services__hamburger'>
++			<a class='o-header-services__hamburger-icon' href="#"">
++				<span class="o-header-services__visually-hidden">Open primary navigation</span>
++			</a>
++		</div>
+		<div class='o-header-services__logo'></div>
+		<div class='o-header-services__title'>
+			<h1 class='o-header-services__product-name'><a href=''>Tool or Service name</a></h1><span class='o-header-subrand__product-tagline '>Tagline to explain the product here</span>
 		</div>
++		<ul class="o-header-services__related-content">
++			<li class="o-header-services__related-content-list-item">
++				<a class="o-header-services__related-content-link" href="#">XXXX</a>
++			</li>
++			<li class="o-header-services__related-content-list-item">
++				<a class="o-header-services__related-content-link" href="#">Sign in</a>
++			</li>
++		</ul>
 	</div>
 </header>
 ```
@@ -111,36 +111,32 @@ This requires the drawer code, as seen above, and the following addition:
 ```diff
 <header class='o-header-services' data-o-component='o-header-services'>
 	<div class='o-header-services__top'>
-		<div class='o-header-services__container'>
-			<div class='o-header-services__hamburger'>
-				<a class='o-header-services__hamburger-icon' href="#"><span class="o-header-services__visually-hidden">Menu</span></a>
-			</div>
-			<div class='o-header-services__logo'></div>
-			<div class='o-header-services__title'>
-				<h1 class='o-header-services__product-name'><a href=''>Tool or Service name</a></h1><span class='o-header-services__product-tagline '>Tagline to explain the product here</span>
-			</div>
-			<ul class="o-header-services__related-content">
-				<li class="o-header-services__related-content-list-item">
-					<a class="o-header-services__related-content-link" href="#">XXXX</a>
-				</li>
-				<li class="o-header-services__related-content-list-item">
-					<a class="o-header-services__related-content-link" href="#">Sign in</a>
-				</li>
-			</ul>
+		<div class='o-header-services__hamburger'>
+			<a class='o-header-services__hamburger-icon' href="#"><span class="o-header-services__visually-hidden">Menu</span></a>
 		</div>
+		<div class='o-header-services__logo'></div>
+		<div class='o-header-services__title'>
+			<h1 class='o-header-services__product-name'><a href=''>Tool or Service name</a></h1><span class='o-header-services__product-tagline '>Tagline to explain the product here</span>
+		</div>
+		<ul class="o-header-services__related-content">
+			<li class="o-header-services__related-content-list-item">
+				<a class="o-header-services__related-content-link" href="#">XXXX</a>
+			</li>
+			<li class="o-header-services__related-content-list-item">
+				<a class="o-header-services__related-content-link" href="#">Sign in</a>
+			</li>
+		</ul>
 	</div>
 </header>
 +<nav class='o-header-services__primary-nav'>
-+ <div class='o-header-services__container'>
-+	 <ul class='o-header-services__nav-list'>
-+		 <li class='o-header-services__nav-item'>
-+			 <a class="o-header-services__nav-link  o-header-services__nav-link--selected" href='#'>
-+				 Nav item title
-+			 </a>
-+			</li>
-+			<!-- more nav items -->
-+		</ul>
-+	</div>
++	<ul class='o-header-services__nav-list'>
++	 <li class='o-header-services__nav-item'>
++		 <a class="o-header-services__nav-link  o-header-services__nav-link--selected" href='#'>
++			 Nav item title
++		 </a>
++		</li>
++		<!-- more nav items -->
++	</ul>
 +</nav>
 ```
 
@@ -154,76 +150,70 @@ To use the secondary navigation, use the primary navigation and add the followin
 ```diff
 <header class='o-header-services' data-o-component='o-header-services'>
 	<div class='o-header-services__top'>
-		<div class='o-header-services__container'>
-			<div class='o-header-services__hamburger'>
-				<a class='o-header-services__hamburger-icon' href="#"><span class="o-header-services__visually-hidden">Menu</span></a>
-			</div>
-			<div class='o-header-services__logo'></div>
-			<div class='o-header-services__title'>
-				<h1 class='o-header-services__product-name'><a href=''>Tool or Service name</a></h1><span class='o-header-services__product-tagline '>Tagline to explain the product here</span>
-			</div>
-			<div class='o-header-services__related-content'>
-				<a href='#'>XXXX</a>
-				<a href='#'>Sign in</a>
-			</div>
+		<div class='o-header-services__hamburger'>
+			<a class='o-header-services__hamburger-icon' href="#"><span class="o-header-services__visually-hidden">Menu</span></a>
+		</div>
+		<div class='o-header-services__logo'></div>
+		<div class='o-header-services__title'>
+			<h1 class='o-header-services__product-name'><a href=''>Tool or Service name</a></h1><span class='o-header-services__product-tagline '>Tagline to explain the product here</span>
+		</div>
+		<div class='o-header-services__related-content'>
+			<a href='#'>XXXX</a>
+			<a href='#'>Sign in</a>
 		</div>
 	</div>
 </header>
 <nav class='o-header-services__primary-nav'>
- <div class='o-header-services__container'>
-	 <ul class='o-header-services__nav-list'>
-		 <li class='o-header-services__nav-item o-header-services__nav-item--selected'>
-			 <a href='#'>
-				 Nav item title
-			 </a>
-			</li>
-			<!-- more nav items -->
-		</ul>
-	</div>
+ <ul class='o-header-services__nav-list'>
+	 <li class='o-header-services__nav-item o-header-services__nav-item--selected'>
+		 <a href='#'>
+			 Nav item title
+		 </a>
+		</li>
+		<!-- more nav items -->
+	</ul>
 </nav>
 
-+<nav class="o-header-services__subnav" role="navigation" aria-label="Sub navigation">
-+	<div class="o-header-services__container" data-o-header-services-nav>
-+		<div class="o-header-services__subnav-content" data-o-header-services-nav-list>
-+			<ol class="o-header-services__subnav-list o-header-services__subnav-list--breadcrumb" aria-label="Breadcrumb">
-+				<li class="o-header-services__subnav-item">
-+					<a class="o-header-services__subnav-link" href="#">
-+						ancestor section
-+					</a>
-+				</li>
-+				<li class="o-header-services__subnav-item">
-+					<a class="o-header-services__subnav-link" href="#">
-+						ancestor section
-+					</a>
-+				</li>
-+				<li class="o-header-services__subnav-item">
-+					<a class="o-header-services__subnav-link" href="#" aria-current="true" aria-label="Current page">
-+						current section
-+					</a>
-+				</li>
-+			</ol>
++<nav class="o-header-services__subnav" role="navigation" aria-label="Sub navigation" data-o-header-services-nav>
++	<div class="o-header-services__subnav-content" data-o-header-services-nav-list>
++		<ol class="o-header-services__subnav-list o-header-services__subnav-list--breadcrumb" aria-label="Breadcrumb">
++			<li class="o-header-services__subnav-item">
++				<a class="o-header-services__subnav-link" href="#">
++					ancestor section
++				</a>
++			</li>
++			<li class="o-header-services__subnav-item">
++				<a class="o-header-services__subnav-link" href="#">
++					ancestor section
++				</a>
++			</li>
++			<li class="o-header-services__subnav-item">
++				<a class="o-header-services__subnav-link" href="#" aria-current="true" aria-label="Current page">
++					current section
++				</a>
++			</li>
++		</ol>
 
-+			<ul class="o-header-services__subnav-list o-header-services__subnav-list--children" aria-label="Subsections">
-+				<li class="o-header-services__subnav-item">
-+					<a class="o-header-services__subnav-link" href="{{href}}">
-+						child page
-+					</a>
-+				</li>
-+				<li class="o-header-services__subnav-item">
-+					<a class="o-header-services__subnav-link" href="{{href}}">
-+						child page
-+					</a>
-+				</li>
-+				<li class="o-header-services__subnav-item">
-+					<a class="o-header-services__subnav-link" href="{{href}}">
-+						child page
-+					</a>
-+				</li>
-+			</ul>
-+		</div>
++		<ul class="o-header-services__subnav-list o-header-services__subnav-list--children" aria-label="Subsections">
++			<li class="o-header-services__subnav-item">
++				<a class="o-header-services__subnav-link" href="{{href}}">
++					child page
++				</a>
++			</li>
++			<li class="o-header-services__subnav-item">
++				<a class="o-header-services__subnav-link" href="{{href}}">
++					child page
++				</a>
++			</li>
++			<li class="o-header-services__subnav-item">
++				<a class="o-header-services__subnav-link" href="{{href}}">
++					child page
++				</a>
++			</li>
++		</ul>
++	</div>
 +		<button class="o-header-services__scroll-button o-header-services__scroll-button--left" title="scroll left" aria-hidden="true" disabled></button>
 +		<button class="o-header-services__scroll-button o-header-services__scroll-button--right" title="scroll right" aria-hidden="true" disabled></button>
-+	</div>
 +</nav>
 
 ```
@@ -235,78 +225,9 @@ For example, in the case of using both primary and secondary navigation:
 ```diff
 -<header class='o-header-services' data-o-component='o-header'>
 +<header class='o-header-services o-header-services--bleed' data-o-component='o-header'>
-	<div class='o-header-services__top'>
-		<div class='o-header-services__container'>
-			<div class='o--if-js o-header-services__hamburger'>
-				<a class='o-header-services__hamburger-icon' href="#o-header-drawer"	aria-controls="o-header-drawer"><span class="o-header__visually-hidden">Menu</span></a>
-			</div>
-			<div class='o-header-services__logo'></div>
-			<div class='o-header-services__title'>
-				<h1 class='o-header-services__product-name'><a href=''>Tool or Service name</a></h1><span class='o-header-subrand__product-tagline '>Tagline to explain the product here</span>
-			</div>
-			<div class='o-header-services__related-content'>
-				<a href='#'>XXXX</a>
-				<a href='#'>Sign in</a>
-			</div>
-		</div>
-	</div>
+	<!-- header markup -->
 </header>
-<nav class='o-header-services__primary-nav'>
-	<div class='o-header-services__container'>
-		<ul class='o-header-services__nav-list'>
-			<li class='o-header-services__nav-item o-header-services__nav-item--selected'>
-				<a href='#'>
-					Nav item title
-				</a>
-			</li>
-			<!-- more nav items -->
-		</ul>
-	</div>
-</nav>
-
-<nav class="o-header-services__subnav" role="navigation" aria-label="Sub navigation">
-	<div class="o-header-services__container" data-o-header-services-nav>
-		<div class="o-header-services__subnav-content" data-o-header-services-nav-list>
-			<ol class="o-header-services__subnav-list o-header-services__subnav-list--breadcrumb" aria-label="Breadcrumb">
-				<li class="o-header-services__subnav-item">
-					<a class="o-header-services__subnav-link" href="#">
-						ancestor section
-					</a>
-				</li>
-				<li class="o-header-services__subnav-item">
-					<a class="o-header-services__subnav-link" href="#">
-						ancestor section
-					</a>
-				</li>
-				<li class="o-header-services__subnav-item">
-					<a class="o-header-services__subnav-link" href="#" aria-current="true" aria-label="Current page">
-						current section
-					</a>
-				</li>
-			</ol>
-
-			<ul class="o-header-services__subnav-list o-header-services__subnav-list--children" aria-label="Subsections">
-				<li class="o-header-services__subnav-item">
-					<a class="o-header-services__subnav-link" href="{{href}}">
-						child page
-					</a>
-				</li>
-				<li class="o-header-services__subnav-item">
-					<a class="o-header-services__subnav-link" href="{{href}}">
-						child page
-					</a>
-				</li>
-				<li class="o-header-services__subnav-item">
-					<a class="o-header-services__subnav-link" href="{{href}}">
-						child page
-					</a>
-				</li>
-			</ul>
-		</div>
-		<button class="o-header-services__scroll-button o-header-services__scroll-button--left" title="scroll left" aria-hidden="true" disabled></button>
-		<button class="o-header-services__scroll-button o-header-services__scroll-button--right" title="scroll right" aria-hidden="true" disabled></button>
-	</div>
-</nav>
+	<!-- nav and subnav markup -->
 ```
 
 ## Sass
@@ -332,7 +253,8 @@ The markup for a full header has changed in the following way:
 ```diff
 -<header class="o-header-services" data-o-component="o-header">
 +<header class='o-header-services' data-o-component='o-header-services'>
-	<div class="o-header-services__top o-header-services__container">
+-	<div class="o-header-services__top o-header-services__container">
++	<div class="o-header-services__top">
 		<div class='o-header-services__hamburger'>
 			<a class='o-header-services__hamburger-icon' href="#">
 -				<span class="o-header__visually-hidden">Menu</span>
@@ -360,7 +282,7 @@ The markup for a full header has changed in the following way:
 	</div>
 </header>
 <nav class="o-header-services__primary-nav">
-	<div class="o-header-services__container">
+-	<div class="o-header-services__container">
 		<ul class="o-header-services__nav-list">
 			<li class="o-header-services__nav-item">
 				<a class="o-header-services__nav-link o-header-services__nav-link--selected" href="#item-1">
@@ -369,12 +291,12 @@ The markup for a full header has changed in the following way:
 			</li>
 			<!-- more nav items -->
 		</ul>
-	</div>
+-	</div>
 </nav>
 
-<nav class="o-header-services__subnav" role="navigation" aria-label="Sub navigation">
+-<nav class="o-header-services__subnav" role="navigation" aria-label="Sub navigation">
++<nav class="o-header-services__subnav" role="navigation" aria-label="Sub navigation"  data-o-header-services-nav>
 -	<div class="o-header-services__container">
-+	<div class="o-header-services__container" data-o-header-services-nav>
 -		<div class="o-header__subnav-wrap-outside">
 -			<div class="o-header__subnav-wrap-inside">
 -				<div class="o-header-services__subnav-content">
@@ -406,7 +328,7 @@ The markup for a full header has changed in the following way:
 +		<button class="o-header-services__scroll-button o-header-services__scroll-button--right" title="scroll right" aria-hidden="true" disabled></button>
 -			</div>
 -		</div>
-	</div>
+-	</div>
 </nav>
 
 -<!-- All drawer markup has been removed! -->

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -1,87 +1,88 @@
 <header class="o-header-services" data-o-component="o-header-services">
-	<div class="o-header-services__top o-header-services__container">
+	<div class="o-header-services__top">
 		<div class="o-header-services__hamburger">
-			<a class="o-header-services__hamburger-icon" href="#o-header-drawer" aria-controls="o-header-drawer" role="button" data-o-toggle--js="true" aria-expanded="false"><span class="o-header__visually-hidden">Menu</span></a>
+			<a class="o-header-services__hamburger-icon" href="#" role="button" aria-haspopup="true" aria-expanded="false">
+				<span class="o-header-services__visually-hidden">Open primary navigation</span>
+			</a>
 		</div>
 		<div class="o-header-services__logo"></div>
 		<div class="o-header-services__title">
-			<h1 class="o-header-services__product-name"><a href="/">Tool or Service name</a></h1><span class="o-header-subrand__product-tagline">Tagline to explain the product here</span>
+			<h1 class="o-header-services__product-name"><a href="/">Tool or Service name</a></h1>
+			<span class="o-header-services__product-tagline">Tagline to explain the product here</span>
 		</div>
-		<div class="o-header-services__related-content">
-			<a class="o-header-services__related-content-link" href="#">XXXX</a>
-			<a class="o-header-services__related-content-link" href="#">Sign in</a>
-		</div>
+		<ul class="o-header-services__related-content">
+			<li class="o-header-services__related-content-list-item">
+				<a class="o-header-services__related-content-link" href="#">XXXX</a>
+			</li>
+			<li class="o-header-services__related-content-list-item">
+				<a class="o-header-services__related-content-link" href="#">Sign in</a>
+			</li>
+		</ul>
 	</div>
-	<nav class="o-header-services__primary-nav">
-		<div class="o-header-services__nav-container">
-			<ul class="o-header-services__nav-list">
-				<li class="o-header-services__nav-item">
-					<a class="o-header-services__nav-link o-header-services__nav-link--selected" href="#">
-						Nav item 1
+	<nav class="o-header-services__primary-nav" aria-label="Primary">
+		<ul class="o-header-services__nav-list">
+			<li class="o-header-services__nav-item">
+				<a class="o-header-services__nav-link o-header-services__nav-link--selected" href="#">
+					Nav item 1
+				</a>
+			</li>
+			<li class="o-header-services__nav-item">
+				<a class="o-header-services__nav-link" href="#">
+					Nav item 2
+				</a>
+			</li>
+			<li class="o-header-services__nav-item">
+				<a class="o-header-services__nav-link" href="#">
+					Nav item 3
+				</a>
+			</li>
+			<li class="o-header-services__nav-item">
+				<a class="o-header-services__nav-link" href="#">
+					Nav item 4
+				</a>
+			</li>
+		</ul>
+	</nav>
+<!-- sub nav markup -->
+	<nav class="o-header-services__subnav" aria-label="sub"  data-o-header-services-nav>
+		<div class="o-header-services__subnav-content" data-o-header-services-nav-list>
+			<ol class="o-header-services__subnav-list o-header-services__subnav-list--breadcrumb" aria-label="Breadcrumb">
+				<li class="o-header-services__subnav-item">
+					<a class="o-header-services__subnav-link" href="#">
+						ancestor section
 					</a>
 				</li>
-				<li class="o-header-services__nav-item">
-					<a class="o-header-services__nav-link" href="#">
-						Nav item 2
+				<li class="o-header-services__subnav-item">
+					<a class="o-header-services__subnav-link" href="#">
+						ancestor section
 					</a>
 				</li>
-				<li class="o-header-services__nav-item">
-					<a class="o-header-services__nav-link" href="#">
-						Nav item 3
+				<li class="o-header-services__subnav-item">
+					<a class="o-header-services__subnav-link" href="#" >
+						current section
 					</a>
 				</li>
-				<li class="o-header-services__nav-item">
-					<a class="o-header-services__nav-link" href="#">
-						Nav item 4
+			</ol>
+
+			<ul class="o-header-services__subnav-list o-header-services__subnav-list--children" aria-label="Subsections">
+				<li class="o-header-services__subnav-item">
+					<a class="o-header-services__subnav-link" href="{{href}}">
+						child page
+					</a>
+				</li>
+				<li class="o-header-services__subnav-item">
+					<a class="o-header-services__subnav-link" href="{{href}}">
+						child page
+					</a>
+				</li>
+				<li class="o-header-services__subnav-item">
+					<a class="o-header-services__subnav-link" href="{{href}}" aria-current="true" aria-label="Current page">
+						child page
 					</a>
 				</li>
 			</ul>
-			<button class="o-header-services__scroll-button o-header-services__scroll-button--left" aria-hidden="true" disabled></button>
-			<button class="o-header-services__scroll-button o-header-services__scroll-button--right" aria-hidden="true" disabled></button>
 		</div>
-	</nav>
-<!-- sub nav markup -->
-	<nav class="o-header-services__subnav" role="navigation" aria-label="Sub navigation">
-		<div class="o-header-services__container" data-o-header-services-nav>
-			<div class="o-header-services__subnav-content" data-o-header-services-nav-list>
-				<ol class="o-header-services__subnav-list o-header-services__subnav-list--breadcrumb" aria-label="Breadcrumb">
-					<li class="o-header-services__subnav-item">
-						<a class="o-header-services__subnav-link" href="#">
-							ancestor section
-						</a>
-					</li>
-					<li class="o-header-services__subnav-item">
-						<a class="o-header-services__subnav-link" href="#">
-							ancestor section
-						</a>
-					</li>
-					<li class="o-header-services__subnav-item">
-						<a class="o-header-services__subnav-link" href="#" aria-selected="true" aria-label="Current page">
-							current section
-						</a>
-					</li>
-				</ol>
-
-				<ul class="o-header-services__subnav-list o-header-services__subnav-list--children" aria-label="Subsections">
-					<li class="o-header-services__subnav-item">
-						<a class="o-header-services__subnav-link" href="{{href}}">
-							child page
-						</a>
-					</li>
-					<li class="o-header-services__subnav-item">
-						<a class="o-header-services__subnav-link" href="{{href}}">
-							child page
-						</a>
-					</li>
-					<li class="o-header-services__subnav-item">
-						<a class="o-header-services__subnav-link" href="{{href}}">
-							child page
-						</a>
-					</li>
-				</ul>
-			</div>
-			<button class="o-header-services__scroll-button o-header-services__scroll-button--left" title="scroll left" aria-hidden="true" disabled></button>
-			<button class="o-header-services__scroll-button o-header-services__scroll-button--right" title="scroll right" aria-hidden="true" disabled></button>
-		</div>
+		<button class="o-header-services__scroll-button o-header-services__scroll-button--left" title="scroll left" aria-hidden="true" disabled></button>
+		<button class="o-header-services__scroll-button o-header-services__scroll-button--right" title="scroll right" aria-hidden="true" disabled></button>
 	</nav>
 </header>

--- a/demos/src/primary-navigation.mustache
+++ b/demos/src/primary-navigation.mustache
@@ -1,7 +1,10 @@
 <header class="o-header-services" data-o-component="o-header-services">
+
 	<div class="o-header-services__top o-header-services__container">
 		<div class="o-header-services__hamburger">
-			<a class="o-header-services__hamburger-icon" href="#" role="button"><span class="o-header-services__visually-hidden">Menu</span></a>
+			<a class="o-header-services__hamburger-icon" href="#" role="button">
+				<span class="o-header-services__visually-hidden">Open primary navigation</span>
+			</a>
 		</div>
 		<div class="o-header-services__logo"></div>
 		<div class="o-header-services__title">
@@ -18,29 +21,27 @@
 		</ul>
 	</div>
 	<nav class="o-header-services__primary-nav">
-		<div class="o-header-services__container">
-			<ul class="o-header-services__nav-list">
-				<li class="o-header-services__nav-item">
-					<a class="o-header-services__nav-link o-header-services__nav-link--selected" href="#item-1">
-						Nav item 1
-					</a>
-				</li>
-				<li class="o-header-services__nav-item">
-					<a class="o-header-services__nav-link" href="#">
-						Nav item 2
-					</a>
-				</li>
-				<li class="o-header-services__nav-item">
-					<a class="o-header-services__nav-link" href="#">
-						Nav item 3
-					</a>
-				</li>
-				<li class="o-header-services__nav-item">
-					<a class="o-header-services__nav-link" href="#">
-						Nav item 4
-					</a>
-				</li>
-			</ul>
-		</div>
+		<ul class="o-header-services__nav-list">
+			<li class="o-header-services__nav-item">
+				<a class="o-header-services__nav-link o-header-services__nav-link--selected" href="#item-1">
+					Nav item 1
+				</a>
+			</li>
+			<li class="o-header-services__nav-item">
+				<a class="o-header-services__nav-link" href="#">
+					Nav item 2
+				</a>
+			</li>
+			<li class="o-header-services__nav-item">
+				<a class="o-header-services__nav-link" href="#">
+					Nav item 3
+				</a>
+			</li>
+			<li class="o-header-services__nav-item">
+				<a class="o-header-services__nav-link" href="#">
+					Nav item 4
+				</a>
+			</li>
+		</ul>
 	</nav>
 </header>

--- a/demos/src/site-title.mustache
+++ b/demos/src/site-title.mustache
@@ -1,5 +1,5 @@
 <header class="o-header-services" data-o-component="o-header-services">
-	<div class="o-header-services__top o-header-services__container">
+	<div class="o-header-services__top">
 		<div class="o-header-services__logo"></div>
 		<div class="o-header-services__title">
 			<h1 class="o-header-services__product-name"><a href="/">Tool or Service name</a></h1>

--- a/demos/src/sub-navigation.mustache
+++ b/demos/src/sub-navigation.mustache
@@ -1,7 +1,9 @@
 <header class="o-header-services" data-o-component="o-header-services">
 	<div class="o-header-services__top o-header-services__container">
 		<div class="o-header-services__hamburger">
-			<a class="o-header-services__hamburger-icon" href="#" role="button"><span class="o-header-services__visually-hidden">Menu</span></a>
+			<a class="o-header-services__hamburger-icon" href="#" role="button" aria-haspopup="true" aria-expanded="false">
+				<span class="o-header-services__visually-hidden">Show primary navigation</span>
+			</a>
 		</div>
 		<div class="o-header-services__logo"></div>
 		<div class="o-header-services__title">
@@ -17,7 +19,7 @@
 			</li>
 		</ul>
 	</div>
-	<nav class="o-header-services__primary-nav">
+	<nav class="o-header-services__primary-nav" aria-label="Primary">
 		<div class="o-header-services__container">
 			<ul class="o-header-services__nav-list">
 				<li class="o-header-services__nav-item">
@@ -44,7 +46,7 @@
 		</div>
 	</nav>
 <!-- sub nav markup -->
-	<nav class="o-header-services__subnav" role="navigation" aria-label="Sub navigation">
+	<nav class="o-header-services__subnav" aria-label="Sub navigation">
 		<div class="o-header-services__container" data-o-header-services-nav>
 			<div class="o-header-services__subnav-content" data-o-header-services-nav-list>
 				<ol class="o-header-services__subnav-list o-header-services__subnav-list--breadcrumb" aria-label="Breadcrumb">

--- a/demos/src/sub-navigation.mustache
+++ b/demos/src/sub-navigation.mustache
@@ -42,6 +42,7 @@
 				</a>
 			</li>
 		</ul>
+		<button class="o-header-services__visually-hidden" title="close primary navigation"></button>
 	</nav>
 <!-- sub nav markup -->
 	<nav class="o-header-services__subnav" aria-label="sub navigation"  data-o-header-services-nav>

--- a/demos/src/sub-navigation.mustache
+++ b/demos/src/sub-navigation.mustache
@@ -1,8 +1,8 @@
 <header class="o-header-services" data-o-component="o-header-services">
-	<div class="o-header-services__top o-header-services__container">
+	<div class="o-header-services__top">
 		<div class="o-header-services__hamburger">
-			<a class="o-header-services__hamburger-icon" href="#" role="button" aria-haspopup="true" aria-expanded="false">
-				<span class="o-header-services__visually-hidden">Show primary navigation</span>
+			<a class="o-header-services__hamburger-icon" href="#" role="button">
+				<span class="o-header-services__visually-hidden">Open primary navigation</span>
 			</a>
 		</div>
 		<div class="o-header-services__logo"></div>
@@ -19,74 +19,70 @@
 			</li>
 		</ul>
 	</div>
-	<nav class="o-header-services__primary-nav" aria-label="Primary">
-		<div class="o-header-services__container">
-			<ul class="o-header-services__nav-list">
-				<li class="o-header-services__nav-item">
-					<a class="o-header-services__nav-link o-header-services__nav-link--selected" href="#">
-						Nav item 1
+	<nav class="o-header-services__primary-nav" aria-label="primary navigation">
+		<ul class="o-header-services__nav-list">
+			<li class="o-header-services__nav-item">
+				<a class="o-header-services__nav-link o-header-services__nav-link--selected" href="#">
+					Nav item 1
+				</a>
+			</li>
+			<li class="o-header-services__nav-item">
+				<a class="o-header-services__nav-link" href="#">
+					Nav item 2
+				</a>
+			</li>
+			<li class="o-header-services__nav-item">
+				<a class="o-header-services__nav-link" href="#">
+					Nav item 3
+				</a>
+			</li>
+			<li class="o-header-services__nav-item">
+				<a class="o-header-services__nav-link" href="#">
+					Nav item 4
+				</a>
+			</li>
+		</ul>
+	</nav>
+<!-- sub nav markup -->
+	<nav class="o-header-services__subnav" aria-label="sub navigation"  data-o-header-services-nav>
+		<div class="o-header-services__subnav-content" data-o-header-services-nav-list>
+			<ol class="o-header-services__subnav-list o-header-services__subnav-list--breadcrumb" aria-label="Breadcrumb">
+				<li class="o-header-services__subnav-item">
+					<a class="o-header-services__subnav-link" href="#">
+						ancestor section
 					</a>
 				</li>
-				<li class="o-header-services__nav-item">
-					<a class="o-header-services__nav-link" href="#">
-						Nav item 2
+				<li class="o-header-services__subnav-item">
+					<a class="o-header-services__subnav-link" href="#">
+						ancestor section
 					</a>
 				</li>
-				<li class="o-header-services__nav-item">
-					<a class="o-header-services__nav-link" href="#">
-						Nav item 3
+				<li class="o-header-services__subnav-item">
+					<a class="o-header-services__subnav-link" href="#" >
+						current section
 					</a>
 				</li>
-				<li class="o-header-services__nav-item">
-					<a class="o-header-services__nav-link" href="#">
-						Nav item 4
+			</ol>
+
+			<ul class="o-header-services__subnav-list o-header-services__subnav-list--children" aria-label="Subsections">
+				<li class="o-header-services__subnav-item">
+					<a class="o-header-services__subnav-link" href="{{href}}">
+						child page
+					</a>
+				</li>
+				<li class="o-header-services__subnav-item">
+					<a class="o-header-services__subnav-link" href="{{href}}">
+						child page
+					</a>
+				</li>
+				<li class="o-header-services__subnav-item">
+					<a class="o-header-services__subnav-link" href="{{href}}" aria-current="true" aria-label="Current page">
+						child page
 					</a>
 				</li>
 			</ul>
 		</div>
-	</nav>
-<!-- sub nav markup -->
-	<nav class="o-header-services__subnav" aria-label="Sub navigation">
-		<div class="o-header-services__container" data-o-header-services-nav>
-			<div class="o-header-services__subnav-content" data-o-header-services-nav-list>
-				<ol class="o-header-services__subnav-list o-header-services__subnav-list--breadcrumb" aria-label="Breadcrumb">
-					<li class="o-header-services__subnav-item">
-						<a class="o-header-services__subnav-link" href="#">
-							ancestor section
-						</a>
-					</li>
-					<li class="o-header-services__subnav-item">
-						<a class="o-header-services__subnav-link" href="#">
-							ancestor section
-						</a>
-					</li>
-					<li class="o-header-services__subnav-item">
-						<a class="o-header-services__subnav-link" href="#" >
-							current section
-						</a>
-					</li>
-				</ol>
-
-				<ul class="o-header-services__subnav-list o-header-services__subnav-list--children" aria-label="Subsections">
-					<li class="o-header-services__subnav-item">
-						<a class="o-header-services__subnav-link" href="{{href}}">
-							child page
-						</a>
-					</li>
-					<li class="o-header-services__subnav-item">
-						<a class="o-header-services__subnav-link" href="{{href}}">
-							child page
-						</a>
-					</li>
-					<li class="o-header-services__subnav-item">
-						<a class="o-header-services__subnav-link" href="{{href}}" aria-current="true" aria-label="Current page">
-							child page
-						</a>
-					</li>
-				</ul>
-			</div>
-			<button class="o-header-services__scroll-button o-header-services__scroll-button--left" title="scroll left" aria-hidden="true" disabled></button>
-			<button class="o-header-services__scroll-button o-header-services__scroll-button--right" title="scroll right" aria-hidden="true" disabled></button>
-		</div>
+		<button class="o-header-services__scroll-button o-header-services__scroll-button--left" title="scroll left" aria-hidden="true" disabled></button>
+		<button class="o-header-services__scroll-button o-header-services__scroll-button--right" title="scroll right" aria-hidden="true" disabled></button>
 	</nav>
 </header>

--- a/demos/src/theme-b2b.mustache
+++ b/demos/src/theme-b2b.mustache
@@ -1,11 +1,13 @@
 <header class="o-header-services o-header-services--b2b" data-o-component="o-header-services">
-	<div class="o-header-services__top o-header-services__container">
+	<div class="o-header-services__top">
 		<div class="o-header-services__hamburger">
-			<a class="o-header-services__hamburger-icon" href="#" role="button"><span class="o-header-services__visually-hidden">Menu</span></a>
+			<a class="o-header-services__hamburger-icon" href="#" role="button">
+				<span class="o-header-services__visually-hidden">Open primary navigation</span>
+			</a>
 		</div>
 		<div class="o-header-services__logo"></div>
 		<div class="o-header-services__title">
-			<h1 class="o-header-services__product-name"><a href="/">B2B Tool or Service name</a></h1>
+			<h1 class="o-header-services__product-name"><a href="/">Tool or Service name</a></h1>
 			<span class="o-header-services__product-tagline">Tagline to explain the product here</span>
 		</div>
 		<ul class="o-header-services__related-content">
@@ -17,74 +19,70 @@
 			</li>
 		</ul>
 	</div>
-	<nav class="o-header-services__primary-nav">
-		<div class="o-header-services__container">
-			<ul class="o-header-services__nav-list">
-				<li class="o-header-services__nav-item">
-					<a class="o-header-services__nav-link o-header-services__nav-link--selected" href="#">
-						Nav item 1
+	<nav class="o-header-services__primary-nav" aria-label="Primary">
+		<ul class="o-header-services__nav-list">
+			<li class="o-header-services__nav-item">
+				<a class="o-header-services__nav-link o-header-services__nav-link--selected" href="#">
+					Nav item 1
+				</a>
+			</li>
+			<li class="o-header-services__nav-item">
+				<a class="o-header-services__nav-link" href="#">
+					Nav item 2
+				</a>
+			</li>
+			<li class="o-header-services__nav-item">
+				<a class="o-header-services__nav-link" href="#">
+					Nav item 3
+				</a>
+			</li>
+			<li class="o-header-services__nav-item">
+				<a class="o-header-services__nav-link" href="#">
+					Nav item 4
+				</a>
+			</li>
+		</ul>
+	</nav>
+<!-- sub nav markup -->
+	<nav class="o-header-services__subnav" aria-label="Sub navigation"  data-o-header-services-nav>
+		<div class="o-header-services__subnav-content" data-o-header-services-nav-list>
+			<ol class="o-header-services__subnav-list o-header-services__subnav-list--breadcrumb" aria-label="Breadcrumb">
+				<li class="o-header-services__subnav-item">
+					<a class="o-header-services__subnav-link" href="#">
+						ancestor section
 					</a>
 				</li>
-				<li class="o-header-services__nav-item">
-					<a class="o-header-services__nav-link" href="#">
-						Nav item 2
+				<li class="o-header-services__subnav-item">
+					<a class="o-header-services__subnav-link" href="#">
+						ancestor section
 					</a>
 				</li>
-				<li class="o-header-services__nav-item">
-					<a class="o-header-services__nav-link" href="#">
-						Nav item 3
+				<li class="o-header-services__subnav-item">
+					<a class="o-header-services__subnav-link" href="#" >
+						current section
 					</a>
 				</li>
-				<li class="o-header-services__nav-item">
-					<a class="o-header-services__nav-link" href="#">
-						Nav item 4
+			</ol>
+
+			<ul class="o-header-services__subnav-list o-header-services__subnav-list--children" aria-label="Subsections">
+				<li class="o-header-services__subnav-item">
+					<a class="o-header-services__subnav-link" href="{{href}}">
+						child page
+					</a>
+				</li>
+				<li class="o-header-services__subnav-item">
+					<a class="o-header-services__subnav-link" href="{{href}}">
+						child page
+					</a>
+				</li>
+				<li class="o-header-services__subnav-item">
+					<a class="o-header-services__subnav-link" href="{{href}}" aria-current="true" aria-label="Current page">
+						child page
 					</a>
 				</li>
 			</ul>
 		</div>
-	</nav>
-<!-- sub nav markup -->
-	<nav class="o-header-services__subnav" role="navigation" aria-label="Sub navigation">
-		<div class="o-header-services__container" data-o-header-services-nav>
-			<div class="o-header-services__subnav-content" data-o-header-services-nav-list>
-				<ol class="o-header-services__subnav-list o-header-services__subnav-list--breadcrumb" aria-label="Breadcrumb">
-					<li class="o-header-services__subnav-item">
-						<a class="o-header-services__subnav-link" href="#">
-							ancestor section
-						</a>
-					</li>
-					<li class="o-header-services__subnav-item">
-						<a class="o-header-services__subnav-link" href="#">
-							ancestor section
-						</a>
-					</li>
-					<li class="o-header-services__subnav-item">
-						<a class="o-header-services__subnav-link" href="#" aria-current="true" aria-label="Current page">
-							current section
-						</a>
-					</li>
-				</ol>
-
-				<ul class="o-header-services__subnav-list o-header-services__subnav-list--children" aria-label="Subsections">
-					<li class="o-header-services__subnav-item">
-						<a class="o-header-services__subnav-link" href="{{href}}">
-							child page
-						</a>
-					</li>
-					<li class="o-header-services__subnav-item">
-						<a class="o-header-services__subnav-link" href="{{href}}">
-							child page
-						</a>
-					</li>
-					<li class="o-header-services__subnav-item">
-						<a class="o-header-services__subnav-link" href="{{href}}">
-							child page
-						</a>
-					</li>
-				</ul>
-			</div>
-			<button class="o-header-services__scroll-button o-header-services__scroll-button--left" title="scroll left" aria-hidden="true" disabled></button>
-			<button class="o-header-services__scroll-button o-header-services__scroll-button--right" title="scroll right" aria-hidden="true" disabled></button>
-		</div>
+		<button class="o-header-services__scroll-button o-header-services__scroll-button--left" title="scroll left" aria-hidden="true" disabled></button>
+		<button class="o-header-services__scroll-button o-header-services__scroll-button--right" title="scroll right" aria-hidden="true" disabled></button>
 	</nav>
 </header>

--- a/demos/src/theme-b2c.mustache
+++ b/demos/src/theme-b2c.mustache
@@ -1,12 +1,14 @@
 <header class="o-header-services o-header-services--b2c" data-o-component="o-header-services">
-	<div class="o-header-services__top o-header-services__container">
+	<div class="o-header-services__top">
 		<div class="o-header-services__hamburger">
-			<a class="o-header-services__hamburger-icon" href="#" role="button"><span class="o-header-services__visually-hidden">Menu</span></a>
+			<a class="o-header-services__hamburger-icon" href="#" role="button">
+				<span class="o-header-services__visually-hidden">Open primary navigation</span>
+			</a>
 		</div>
 		<div class="o-header-services__logo"></div>
 		<div class="o-header-services__title">
-			<h1 class="o-header-services__product-name"><a href="/">B2C Tool or Service name</a></h1>
-			<span class="o-header-subrand__product-tagline">Tagline to explain the product here</span>
+			<h1 class="o-header-services__product-name"><a href="/">Tool or Service name</a></h1>
+			<span class="o-header-services__product-tagline">Tagline to explain the product here</span>
 		</div>
 		<ul class="o-header-services__related-content">
 			<li class="o-header-services__related-content-list-item">
@@ -17,74 +19,70 @@
 			</li>
 		</ul>
 	</div>
-	<nav class="o-header-services__primary-nav">
-		<div class="o-header-services__container">
-			<ul class="o-header-services__nav-list">
-				<li class="o-header-services__nav-item">
-					<a class="o-header-services__nav-link o-header-services__nav-link--selected" href="#">
-						Nav item 1
+	<nav class="o-header-services__primary-nav" aria-label="Primary">
+		<ul class="o-header-services__nav-list">
+			<li class="o-header-services__nav-item">
+				<a class="o-header-services__nav-link o-header-services__nav-link--selected" href="#">
+					Nav item 1
+				</a>
+			</li>
+			<li class="o-header-services__nav-item">
+				<a class="o-header-services__nav-link" href="#">
+					Nav item 2
+				</a>
+			</li>
+			<li class="o-header-services__nav-item">
+				<a class="o-header-services__nav-link" href="#">
+					Nav item 3
+				</a>
+			</li>
+			<li class="o-header-services__nav-item">
+				<a class="o-header-services__nav-link" href="#">
+					Nav item 4
+				</a>
+			</li>
+		</ul>
+	</nav>
+<!-- sub nav markup -->
+	<nav class="o-header-services__subnav" aria-label="Sub navigation"  data-o-header-services-nav>
+		<div class="o-header-services__subnav-content" data-o-header-services-nav-list>
+			<ol class="o-header-services__subnav-list o-header-services__subnav-list--breadcrumb" aria-label="Breadcrumb">
+				<li class="o-header-services__subnav-item">
+					<a class="o-header-services__subnav-link" href="#">
+						ancestor section
 					</a>
 				</li>
-				<li class="o-header-services__nav-item">
-					<a class="o-header-services__nav-link" href="#">
-						Nav item 2
+				<li class="o-header-services__subnav-item">
+					<a class="o-header-services__subnav-link" href="#">
+						ancestor section
 					</a>
 				</li>
-				<li class="o-header-services__nav-item">
-					<a class="o-header-services__nav-link" href="#">
-						Nav item 3
+				<li class="o-header-services__subnav-item">
+					<a class="o-header-services__subnav-link" href="#" >
+						current section
 					</a>
 				</li>
-				<li class="o-header-services__nav-item">
-					<a class="o-header-services__nav-link" href="#">
-						Nav item 4
+			</ol>
+
+			<ul class="o-header-services__subnav-list o-header-services__subnav-list--children" aria-label="Subsections">
+				<li class="o-header-services__subnav-item">
+					<a class="o-header-services__subnav-link" href="{{href}}">
+						child page
+					</a>
+				</li>
+				<li class="o-header-services__subnav-item">
+					<a class="o-header-services__subnav-link" href="{{href}}">
+						child page
+					</a>
+				</li>
+				<li class="o-header-services__subnav-item">
+					<a class="o-header-services__subnav-link" href="{{href}}" aria-current="true" aria-label="Current page">
+						child page
 					</a>
 				</li>
 			</ul>
 		</div>
-	</nav>
-<!-- sub nav markup -->
-	<nav class="o-header-services__subnav" role="navigation" aria-label="Sub navigation">
-		<div class="o-header-services__container" data-o-header-services-nav>
-			<div class="o-header-services__subnav-content" data-o-header-services-nav-list>
-				<ol class="o-header-services__subnav-list o-header-services__subnav-list--breadcrumb" aria-label="Breadcrumb">
-					<li class="o-header-services__subnav-item">
-						<a class="o-header-services__subnav-link" href="#">
-							ancestor section
-						</a>
-					</li>
-					<li class="o-header-services__subnav-item">
-						<a class="o-header-services__subnav-link" href="#">
-							ancestor section
-						</a>
-					</li>
-					<li class="o-header-services__subnav-item">
-						<a class="o-header-services__subnav-link" href="#" aria-current="true" aria-label="Current page">
-							current section
-						</a>
-					</li>
-				</ol>
-
-				<ul class="o-header-services__subnav-list o-header-services__subnav-list--children" aria-label="Subsections">
-					<li class="o-header-services__subnav-item">
-						<a class="o-header-services__subnav-link" href="{{href}}">
-							child page
-						</a>
-					</li>
-					<li class="o-header-services__subnav-item">
-						<a class="o-header-services__subnav-link" href="{{href}}">
-							child page
-						</a>
-					</li>
-					<li class="o-header-services__subnav-item">
-						<a class="o-header-services__subnav-link" href="{{href}}">
-							child page
-						</a>
-					</li>
-				</ul>
-			</div>
-			<button class="o-header-services__scroll-button o-header-services__scroll-button--left" title="scroll left" aria-hidden="true" disabled></button>
-			<button class="o-header-services__scroll-button o-header-services__scroll-button--right" title="scroll right" aria-hidden="true" disabled></button>
-		</div>
+		<button class="o-header-services__scroll-button o-header-services__scroll-button--left" title="scroll left" aria-hidden="true" disabled></button>
+		<button class="o-header-services__scroll-button o-header-services__scroll-button--right" title="scroll right" aria-hidden="true" disabled></button>
 	</nav>
 </header>

--- a/src/js/drop-down.js
+++ b/src/js/drop-down.js
@@ -14,12 +14,12 @@ class DropDown {
 		if (!this.nav) { return; }
 
 		this.burger = this.headerEl.querySelector('.o-header-services__hamburger-icon');
-		this.burger.addEventListener('click', this.toggleNav.bind(this));
+		this.burger.addEventListener('click', this.toggleDropdown.bind(this));
 
 		window.addEventListener('resize', oUtils.debounce(this.render.bind(this), 100));
 		window.addEventListener('keydown', (e) => {
 			if (e.key === 'Escape' && !this.nav.classList.contains(this.class.hidden)) {
-				this._swapClasses(this.class.open, this.class.hidden, false);
+				this._dropNav(this.class.open, this.class.hidden, false);
 			}
 		});
 
@@ -30,9 +30,9 @@ class DropDown {
 		const enableDropdown = oGrid.getCurrentLayout() === 'default' || oGrid.getCurrentLayout() === 'S';
 
 		if (enableDropdown) {
-			this.nav.addEventListener('click', this.toggleNav.bind(this));
+			this.nav.addEventListener('click', this.toggleDropdown.bind(this));
 		} else {
-			this.nav.removeEventListener('click', this.toggleNav);
+			this.nav.removeEventListener('click', this.toggleDropdown);
 		}
 
 		this._shiftRelatedContentList(enableDropdown);
@@ -41,11 +41,11 @@ class DropDown {
 		this.nav.setAttribute('aria-hidden', enableDropdown);
 	}
 
-	toggleNav () {
+	toggleDropdown () {
 		if (this.nav.classList.contains(this.class.hidden)) {
-			this._swapClasses(this.class.hidden, this.class.open, true);
+			this._dropNav(this.class.hidden, this.class.open, true);
 		} else {
-			this._swapClasses(this.class.open, this.class.hidden, false);
+			this._dropNav(this.class.open, this.class.hidden, false);
 		}
 	}
 
@@ -60,7 +60,7 @@ class DropDown {
 		relatedContent.forEach(item => shiftItems ? navList.appendChild(item) : relatedContentList.appendChild(item));
 	}
 
-	_swapClasses (existingClass, newClass, expand) {
+	_dropNav (existingClass, newClass, expand) {
 		this.nav.classList.remove(existingClass);
 		// display: none doesn't work with keyframes, so the element needs to be
 		// rendered before animated on open and animated before hidden on close
@@ -75,10 +75,10 @@ class DropDown {
 		if (expand) {
 			this.burger.querySelector('span').innerText = 'Close primary navigation';
 			this.nav.querySelector('.o-header-services__nav-link').focus();
-			this.nav.lastElementChild.addEventListener('focusout', () => this._swapClasses(this.class.open, this.class.hidden, false));
+			this.nav.lastElementChild.addEventListener('focusout', () => this._dropNav(this.class.open, this.class.hidden, false));
 		} else {
 			this.burger.querySelector('span').innerText = 'Open primary navigation';
-			this.nav.lastElementChild.removeEventListener('focusout', this._swapClasses);
+			this.nav.lastElementChild.removeEventListener('focusout', this._dropNav);
 		}
 	}
 }

--- a/src/js/drop-down.js
+++ b/src/js/drop-down.js
@@ -59,13 +59,6 @@ class DropDown {
 		// display: none doesn't work with keyframes, so the element needs to be
 		// rendered before animated on open and animated before hidden on close
 		setTimeout(() => this.nav.classList.add(newClass), 100);
-		this._toggleNavTabbing(tabbing);
-	}
-
-
-	_toggleNavTabbing (isEnabled) {
-		const allFocusable = Array.from(this.nav.querySelectorAll('a, button, input, select'));
-		allFocusable.forEach(el => isEnabled ? el.removeAttribute('tabindex'): el.setAttribute('tabindex', '-1'));
 	}
 }
 

--- a/src/js/drop-down.js
+++ b/src/js/drop-down.js
@@ -17,23 +17,28 @@ class DropDown {
 		this.burger.addEventListener('click', this.toggleNav.bind(this));
 
 		window.addEventListener('resize', oUtils.debounce(this.render.bind(this), 100));
+		window.addEventListener('keydown', (e) => {
+			if (e.key === 'Escape' && !this.nav.classList.contains(this.class.hidden)) {
+				this._swapClasses(this.class.open, this.class.hidden, false)
+			}
+		});
 
 		this.render();
 	}
 
 	render () {
-		const layout = oGrid.getCurrentLayout();
-		if (layout === 'default' || layout === 'S') {
-			this._shiftRelatedContentList(true);
-			this.nav.classList.add(this.class.dropdown, this.class.hidden);
-			this.nav.setAttribute('aria-hidden', true);
+		const enableDropdown = oGrid.getCurrentLayout() === 'default' || oGrid.getCurrentLayout() === 'S';
+
+		if (enableDropdown) {
 			this.nav.addEventListener('click', this.toggleNav.bind(this));
 		} else {
-			this._shiftRelatedContentList(false);
-			this.nav.classList.remove(this.class.dropdown, this.class.hidden);
-			this.nav.setAttribute('aria-hidden', false);
-			this.nav.addEventListener('click', this.toggleNav.bind(this));
+			this.nav.removeEventListener('click', this.toggleNav);
 		}
+
+		this._shiftRelatedContentList(enableDropdown);
+		this.nav.classList.toggle(this.class.dropdown, enableDropdown)
+		this.nav.classList.toggle(this.class.hidden, enableDropdown)
+		this.nav.setAttribute('aria-hidden', enableDropdown);
 	}
 
 	toggleNav () {
@@ -65,14 +70,15 @@ class DropDown {
 
 	_toggleAriaAttributes(expand) {
 		this.nav.setAttribute('aria-hidden', !expand);
+		this.nav.lastElementChild.setAttribute('aria-hidden', !expand);
 		this.burger.setAttribute('aria-expanded', expand);
 		if (expand) {
 			this.burger.querySelector('span').innerText = 'Close primary navigation';
-			// this.burger.focus()
-			this.nav.querySelector('.o-header-services__nav-link').focus()
+			this.nav.querySelector('.o-header-services__nav-link').focus();
+			this.nav.lastElementChild.addEventListener('focusout', () => this._swapClasses(this.class.open, this.class.hidden, false))
 		} else {
 			this.burger.querySelector('span').innerText = 'Open primary navigation';
-			this.burger.focus();
+			this.nav.lastElementChild.removeEventListener('focusout', this._swapClasses);
 		};
 	}
 }

--- a/src/js/drop-down.js
+++ b/src/js/drop-down.js
@@ -19,7 +19,8 @@ class DropDown {
 		window.addEventListener('resize', oUtils.debounce(this.render.bind(this), 100));
 		window.addEventListener('keydown', (e) => {
 			if (e.key === 'Escape' && !this.nav.classList.contains(this.class.hidden)) {
-				this._dropNav(this.class.open, this.class.hidden, false);
+				this.toggleDropdown();
+				this.burger.focus();
 			}
 		});
 
@@ -42,10 +43,19 @@ class DropDown {
 	}
 
 	toggleDropdown () {
-		if (this.nav.classList.contains(this.class.hidden)) {
-			this._dropNav(this.class.hidden, this.class.open, true);
+		const toggle = this.nav.classList.contains(this.class.hidden);
+		if (toggle) {
+			this.nav.classList.remove(this.class.hidden);
+			// display: none doesn't work with keyframes,
+			// so the element needs to be rendered before animated on open
+			setTimeout(() => this.nav.classList.add(this.class.open), 100);
+			this._toggleAriaAttributes(toggle);
 		} else {
-			this._dropNav(this.class.open, this.class.hidden, false);
+			this.nav.classList.remove(this.class.open);
+			// display: none doesn't work with keyframes,
+			// so the element needs to be animated before hidden on close
+			setTimeout(() => this.nav.classList.add(this.class.hidden), 100);
+			this._toggleAriaAttributes(!toggle);
 		}
 	}
 
@@ -60,14 +70,6 @@ class DropDown {
 		relatedContent.forEach(item => shiftItems ? navList.appendChild(item) : relatedContentList.appendChild(item));
 	}
 
-	_dropNav (existingClass, newClass, expand) {
-		this.nav.classList.remove(existingClass);
-		// display: none doesn't work with keyframes, so the element needs to be
-		// rendered before animated on open and animated before hidden on close
-		setTimeout(() => this.nav.classList.add(newClass), 100);
-		this._toggleAriaAttributes(expand);
-	}
-
 	_toggleAriaAttributes(expand) {
 		this.nav.setAttribute('aria-hidden', !expand);
 		this.nav.lastElementChild.setAttribute('aria-hidden', !expand);
@@ -75,10 +77,10 @@ class DropDown {
 		if (expand) {
 			this.burger.querySelector('span').innerText = 'Close primary navigation';
 			this.nav.querySelector('.o-header-services__nav-link').focus();
-			this.nav.lastElementChild.addEventListener('focusout', () => this._dropNav(this.class.open, this.class.hidden, false));
+			this.nav.lastElementChild.addEventListener('focusout', () => this.toggleDropdown.bind(this));
 		} else {
 			this.burger.querySelector('span').innerText = 'Open primary navigation';
-			this.nav.lastElementChild.removeEventListener('focusout', this._dropNav);
+			this.nav.lastElementChild.removeEventListener('focusout', this.toggleDropdown);
 		}
 	}
 }

--- a/src/js/drop-down.js
+++ b/src/js/drop-down.js
@@ -19,7 +19,7 @@ class DropDown {
 		window.addEventListener('resize', oUtils.debounce(this.render.bind(this), 100));
 		window.addEventListener('keydown', (e) => {
 			if (e.key === 'Escape' && !this.nav.classList.contains(this.class.hidden)) {
-				this._swapClasses(this.class.open, this.class.hidden, false)
+				this._swapClasses(this.class.open, this.class.hidden, false);
 			}
 		});
 
@@ -36,8 +36,8 @@ class DropDown {
 		}
 
 		this._shiftRelatedContentList(enableDropdown);
-		this.nav.classList.toggle(this.class.dropdown, enableDropdown)
-		this.nav.classList.toggle(this.class.hidden, enableDropdown)
+		this.nav.classList.toggle(this.class.dropdown, enableDropdown);
+		this.nav.classList.toggle(this.class.hidden, enableDropdown);
 		this.nav.setAttribute('aria-hidden', enableDropdown);
 	}
 
@@ -75,11 +75,11 @@ class DropDown {
 		if (expand) {
 			this.burger.querySelector('span').innerText = 'Close primary navigation';
 			this.nav.querySelector('.o-header-services__nav-link').focus();
-			this.nav.lastElementChild.addEventListener('focusout', () => this._swapClasses(this.class.open, this.class.hidden, false))
+			this.nav.lastElementChild.addEventListener('focusout', () => this._swapClasses(this.class.open, this.class.hidden, false));
 		} else {
 			this.burger.querySelector('span').innerText = 'Open primary navigation';
 			this.nav.lastElementChild.removeEventListener('focusout', this._swapClasses);
-		};
+		}
 	}
 }
 

--- a/src/js/drop-down.js
+++ b/src/js/drop-down.js
@@ -67,8 +67,11 @@ class DropDown {
 		this.nav.setAttribute('aria-hidden', !expand);
 		this.burger.setAttribute('aria-expanded', expand);
 		if (expand) {
+			this.burger.querySelector('span').innerText = 'Close primary navigation';
+			// this.burger.focus()
 			this.nav.querySelector('.o-header-services__nav-link').focus()
 		} else {
+			this.burger.querySelector('span').innerText = 'Open primary navigation';
 			this.burger.focus();
 		};
 	}

--- a/src/js/drop-down.js
+++ b/src/js/drop-down.js
@@ -13,8 +13,8 @@ class DropDown {
 
 		if (!this.nav) { return; }
 
-		let burger = this.headerEl.querySelector('.o-header-services__hamburger-icon');
-		burger.addEventListener('click', this.toggleNav.bind(this));
+		this.burger = this.headerEl.querySelector('.o-header-services__hamburger-icon');
+		this.burger.addEventListener('click', this.toggleNav.bind(this));
 
 		window.addEventListener('resize', oUtils.debounce(this.render.bind(this), 100));
 
@@ -31,6 +31,7 @@ class DropDown {
 		} else {
 			this._shiftRelatedContentList(false);
 			this.nav.classList.remove(this.class.dropdown, this.class.hidden);
+			this.nav.setAttribute('aria-hidden', false);
 			this.nav.addEventListener('click', this.toggleNav.bind(this));
 		}
 	}
@@ -54,11 +55,22 @@ class DropDown {
 		relatedContent.forEach(item => shiftItems ? navList.appendChild(item) : relatedContentList.appendChild(item));
 	}
 
-	_swapClasses (existingClass, newClass, tabbing) {
+	_swapClasses (existingClass, newClass, expand) {
 		this.nav.classList.remove(existingClass);
 		// display: none doesn't work with keyframes, so the element needs to be
 		// rendered before animated on open and animated before hidden on close
 		setTimeout(() => this.nav.classList.add(newClass), 100);
+		this._toggleAriaAttributes(expand);
+	}
+
+	_toggleAriaAttributes(expand) {
+		this.nav.setAttribute('aria-hidden', !expand);
+		this.burger.setAttribute('aria-expanded', expand);
+		if (expand) {
+			this.nav.querySelector('.o-header-services__nav-link').focus()
+		} else {
+			this.burger.focus();
+		};
 	}
 }
 

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -22,15 +22,12 @@
 		.o-header-services__visually-hidden {
 			@include oNormaliseVisuallyHidden;
 		}
-
-		.o-header-services__container {
-			@include oGridContainer;
-		}
 	}
 
 	@if $bleed {
 		.o-header-services--bleed {
-			.o-header-services__container {
+			.o-header-services__top,
+			.o-header-services__primary-nav {
 				@include oGridContainer($bleed: $bleed)
 				max-width: 100%;
 				padding: 0 20px;

--- a/src/scss/_primary-nav.scss
+++ b/src/scss/_primary-nav.scss
@@ -7,12 +7,13 @@
 	}
 
 	.o-header-services__nav-list {
+		@include oGridContainer;
 		background-color: _oHeaderServicesGet('nav-background');
-		min-width: 170px;
-		max-width: max-content;
 		display: flex;
-		padding: 0;
-		margin: 0 (0 - ($_o-header-services-padding-x * 2));
+		margin: auto;
+		@include oGridRespondTo(S) {
+			padding: 0;
+		};
 	}
 
 	.o-header-services__nav-link {
@@ -45,7 +46,10 @@
 			transition: transform 0.5s $o-visual-effects-transition-expand;
 			transform: translate3d(0, -100%, 0);
 			flex-direction: column;
-			margin: 0;
+			margin: 0 0 0 10px;
+			padding: 0;
+			min-width: 170px;
+			max-width: max-content;
 		}
 
 		&.o-header-services__primary-nav--hidden {

--- a/src/scss/_sub-nav.scss
+++ b/src/scss/_sub-nav.scss
@@ -1,20 +1,19 @@
 /// Styling for sub nav
 @mixin oHeaderServicesSubNav() {
 	.o-header-services__subnav {
+		position: relative;
 		background-color: _oHeaderServicesGet('nav-background');
 		border-bottom: 1px solid _oHeaderServicesGet('nav-border');
-		height: $_o-header-services-sub-nav-height;
 		overflow: hidden;
-
-		.o-header-services__container {
-			height: $_o-header-services-sub-nav-height;
-		}
+		height: $_o-header-services-sub-nav-height;
 	}
 
 	.o-header-services__subnav-content {
+		@include oGridContainer;
 		display: flex;
 		white-space: nowrap;
 		overflow: auto;
+		padding: 0 20px;
 	}
 
 	.o-header-services__subnav-list {
@@ -107,7 +106,7 @@
 		@include oButtonsTheme($theme: $_o-header-services-button-theme);
 		position: absolute;
 		top: 0;
-		height: 100%;
+		bottom: 0;
 		transition: opacity 0.5s $o-visual-effects-transition-fade;
 		display: inline-block;
 		min-width:  oTypographySpacingSize(6);

--- a/src/scss/_top.scss
+++ b/src/scss/_top.scss
@@ -3,6 +3,7 @@
 
 @mixin oHeaderServicesTop($logo: $o-header-services-default-logo) {
 	.o-header-services__top {
+		@include oGridContainer;
 		display: flex;
 		color: _oHeaderServicesGet('top-text');
 		background-color: _oHeaderServicesGet('top-background');


### PR DESCRIPTION
Addresses @notlee's previous comments on a11y.

> As the div is nested within the nav element MacOS Voicer announces there is only one nav item.
   
All wrapping containers have been removed, so the `<nav>` elements are now the parent elements, and read by screen readers  

> When the menu is open it's possible to navigate past the menu to content behind (whilst keeping the menu open). We might want to trap focus until it is closed. 

Though people agree with focus trapping, it doesn't seem to work with screen reader commands. Instead, we're closing the dropdown nav on `esc` keydown, `focusout` and clicking outside of the menu, in addition to collapsing the menu when we click on the burger button a second time.
 There is a visually hidden button at the end of the primary nav that also collapses it.  

>It's not obvious the draw has been opened and you have to go through the heading content after opening it to get to the links. We might want to announce the menu has been opened and place focus on/in it  

Focus is now immediately placed on the first nav item when the menu drops down

>There's no clear "close menu" button using voiceover/keyboard navigation.  

there are two buttons now (one visible, one not), as mentioned above

**caveat**: README is still for signposting, will update properly in another PR.