### PR TITLE
Add whitelabel

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ At smaller screen widths this will be included in the drop down navigation.
 
 #### Core experience of the drawer
 
-Small screen users should still be able to access the contents of the drop down navigation even if their browser doesn't cut the mustard or the JavaScript has failed to load. This does is not part of `o-header-services`, but we recommend you have the contents of the drop down navigation at the bottom of the page in a footer that is only visible if the body has a `.core` class. In core experience the hamburger menu should link to an anchor at the bottom of the page.
+Small screen users should still be able to access the contents of the drop down navigation even if their browser doesn't cut the mustard or the JavaScript has failed to load. This is not part of `o-header-services`, but we recommend you have the contents of the drop down navigation at the bottom of the page in a footer that is only visible if the body has a `.core` class. In core experience the hamburger menu should link to an anchor at the bottom of the page.
 
 To add support for related content, add the following to your markup:
 

--- a/main.scss
+++ b/main.scss
@@ -9,6 +9,7 @@
 @import 'src/scss/brand';
 @import 'src/scss/base';
 @import 'src/scss/variables';
+@import 'src/scss/drawer';
 @import 'src/scss/top';
 @import 'src/scss/theme';
 @import 'src/scss/primary-nav';

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -1,6 +1,6 @@
-/// Fundamental styles for header
-/// @param {Boolean} $bleed [whether or not to make the header a bleed header. Defaults to false.]
 /// @access private
+/// @param {Boolean} $bleed [whether or not to make the header a bleed header. Defaults to false.]
+/// @outputs base styles for full header
 @mixin _oHeaderServicesBase($bleed: false) {
 	//Surface layouts for o-grid JavaScript helper https://github.com/Financial-Times/o-grid#getcurrentlayout
 	@include oGridSurfaceCurrentLayout();
@@ -45,6 +45,9 @@
 	}
 }
 
+/// @access private
+/// @param {Boolean} $underline [whether or not to make the hover an underline or a background change]
+/// @outputs hover styles
 @mixin _oHeaderServicesHover($underline) {
 	color: _oHeaderServicesGet('nav-text');
 	position: relative;
@@ -67,7 +70,7 @@
 	} @else {
 		display: block;
 		margin: 0;
-		padding: $_o-header-services-padding-y $_o-header-services-padding-x*2;
+		padding: $_o-header-services-padding $_o-header-services-padding*2;
 
 		&:hover,
 		&[aria-current=true] {

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -44,3 +44,35 @@
 		}
 	}
 }
+
+@mixin _oHeaderServicesHover($underline) {
+	color: _oHeaderServicesGet('nav-text');
+	position: relative;
+
+	@if $underline {
+		display: inline-block;
+		margin: 0 20px;
+		padding: 10px 0;
+
+		&:hover:after,
+		&[aria-current=true]:after {
+			content: '';
+			position: absolute;
+			bottom: 0;
+			left: 0;
+			width: 100%;
+			height: oTypographySpacingSize(1);
+			background-color: _oHeaderServicesGet('nav-text');
+		}
+	} @else {
+		display: block;
+		margin: 0;
+		padding: $_o-header-services-padding-y $_o-header-services-padding-x*2;
+
+		&:hover,
+		&[aria-current=true] {
+			color: inherit;
+			background-color: _oHeaderServicesGet('nav-hover-background');
+		}
+	}
+}

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -30,7 +30,7 @@
 				product-title: oColorsGetPaletteColor('org-b2c-light'),
 				nav-text: oColorsGetPaletteColor('white'),
 				nav-background: oColorsGetPaletteColor('org-b2c'),
-				nav-hover-background: oColorsGetPaletteColor('org-b2c-dark')
+				nav-hover-background: oColorsGetPaletteColor('org-b2c-dark'),
 			)
 		),
 		'supports-variants': (
@@ -47,13 +47,22 @@
 			nav-text: oColorsGetPaletteColor('black'),
 			nav-background: oColorsGetPaletteColor('slate-white-5'),
 			nav-border: oColorsGetPaletteColor('black-20'),
-			nav-hover-background: oColorsGetPaletteColor('slate-white-15')
+			nav-hover-background: oColorsGetPaletteColor('slate-white-15'),
 		),
 		'supports-variants': ()
 	));
 } @elseif oBrandGetCurrentBrand() == 'whitelabel' {
 	@include oBrandDefine('o-header-services', 'whitelabel', (
-		'variables': (),
+		'variables': (
+			logo: null,
+			top-text: oColorsGetPaletteColor('white'),
+			top-background: oColorsGetPaletteColor('black'),
+			nav-text: oColorsGetPaletteColor('black'),
+			nav-background: oColorsGetPaletteColor('white'),
+			nav-border: oColorsGetPaletteColor('black'),
+			nav-hover-background: oColorsGetPaletteColor('white'),
+			underline-hover: true
+		),
 		'supports-variants': ()
 	));
 }

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -60,8 +60,7 @@
 			nav-text: oColorsGetPaletteColor('black'),
 			nav-background: oColorsGetPaletteColor('white'),
 			nav-border: oColorsGetPaletteColor('black'),
-			nav-hover-background: oColorsGetPaletteColor('white'),
-			underline-hover: true
+			nav-hover-background: oColorsGetPaletteColor('white')
 		),
 		'supports-variants': ()
 	));

--- a/src/scss/_drawer.scss
+++ b/src/scss/_drawer.scss
@@ -1,3 +1,5 @@
+/// @access private
+/// @outputs styling for the drawer
 @mixin _oHeaderServicesDrawer {
 	.o-header-services__primary-nav--drawer {
 		background-color: rgba(0, 0, 0, 0.2);

--- a/src/scss/_drawer.scss
+++ b/src/scss/_drawer.scss
@@ -30,12 +30,12 @@
 
 				a {
 					color: inherit;
-					font-weight: unset;
+					font-weight: oFontsWeight('regular');
 					text-transform: none;
 				}
 
 				a:hover {
-					background-color: unset;
+					background-color: none;
 				}
 			}
 		}

--- a/src/scss/_drawer.scss
+++ b/src/scss/_drawer.scss
@@ -1,0 +1,54 @@
+@mixin _oHeaderServicesDrawer {
+	.o-header-services__primary-nav--drawer {
+		background-color: rgba(0, 0, 0, 0.2);
+		position: absolute;
+		top: $_o-header-services-top-bar-short;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		overflow-y: auto;
+		z-index: $_o-header-services-primary-nav-z-index;
+
+		.o-header-services__primary-nav-list {
+			@include oVisualEffectsShadowsElevation('mid');
+			flex-direction: column;
+			margin: 0;
+			padding: 0;
+			transition: transform 0.5s $o-visual-effects-transition-expand;
+			transform: translate3d(-100%, 0, 0);
+			height: 100%;
+			width: calc(100% - 120px);
+		}
+
+		.o-header-services__related-content {
+			display: block;
+			margin: 20px 0 0;
+			padding: 0;
+
+			li {
+				background-color: _oHeaderServicesGet('nav-background');
+
+				a {
+					color: inherit;
+					font-weight: unset;
+					text-transform: none;
+				}
+
+				a:hover {
+					background-color: unset;
+				}
+			}
+		}
+
+		&.o-header-services__primary-nav--hidden {
+			animation: opacity 0.5s $o-visual-effects-transition-fade;
+			display: none;
+		}
+
+		&.o-header-services__primary-nav--open {
+			.o-header-services__primary-nav-list {
+				transform: translate3d(0, 0, 0);
+			}
+		}
+	}
+}

--- a/src/scss/_primary-nav.scss
+++ b/src/scss/_primary-nav.scss
@@ -17,71 +17,12 @@
 		};
 
 		a {
+			$underline: _oHeaderServicesGet('underline-hover');
+			@include _oHeaderServicesHover($underline);
 			@include oTypographyBold('sans');
-			color: _oHeaderServicesGet('nav-text');
 			text-transform: uppercase;
-			display: block;
-			margin: 0;
-			padding: $_o-header-services-padding-y $_o-header-services-padding-x*2;
-
-			&:hover,
-			&[aria-current=true] {
-				color: inherit;
-				background-color: _oHeaderServicesGet('nav-hover-background');
-			}
 		}
 	}
 
-	.o-header-services__primary-nav--drawer {
-		background-color: rgba(0, 0, 0, 0.2);
-		position: absolute;
-		top: $_o-header-services-top-bar-short;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		overflow-y: auto;
-		z-index: $_o-header-services-primary-nav-z-index;
-
-		.o-header-services__primary-nav-list {
-			@include oVisualEffectsShadowsElevation('mid');
-			flex-direction: column;
-			margin: 0;
-			padding: 0;
-			transition: transform 0.5s $o-visual-effects-transition-expand;
-			transform: translate3d(-100%, 0, 0);
-			height: 100%;
-			width: calc(100% - 80px);
-		}
-
-		.o-header-services__related-content {
-			display: block;
-			margin: 20px 0 0;
-			padding: 0;
-
-			li {
-				background-color: _oHeaderServicesGet('nav-background');
-
-				a {
-					color: inherit;
-					font-weight: unset;
-					text-transform: none;
-				}
-
-				a:hover {
-					background-color: unset;
-				}
-			}
-		}
-
-		&.o-header-services__primary-nav--hidden {
-			animation: opacity 0.5s $o-visual-effects-transition-fade;
-			display: none;
-		}
-
-		&.o-header-services__primary-nav--open {
-			.o-header-services__primary-nav-list {
-				transform: translate3d(0, 0, 0);
-			}
-		}
-	}
+	@include _oHeaderServicesDrawer();
 };

--- a/src/scss/_primary-nav.scss
+++ b/src/scss/_primary-nav.scss
@@ -17,7 +17,7 @@
 		};
 
 		a {
-			$underline: _oHeaderServicesGet('underline-hover');
+			$underline: _oHeaderServicesGet('nav-background') == _oHeaderServicesGet('nav-hover-background');
 			@include _oHeaderServicesHover($underline);
 			@include oTypographyBold('sans');
 			text-transform: uppercase;

--- a/src/scss/_primary-nav.scss
+++ b/src/scss/_primary-nav.scss
@@ -1,5 +1,5 @@
-/// Styling for primary nav
 /// @access private
+/// @outputs styling for primary nav
 @mixin _oHeaderServicesPrimaryNav() {
 	.o-header-services__primary-nav {
 		position: relative;

--- a/src/scss/_secondary-nav.scss
+++ b/src/scss/_secondary-nav.scss
@@ -1,5 +1,5 @@
-/// Styling for sub nav
 /// @access private
+/// @outputs styling for sub nav
 @mixin _oHeaderServicesSecondaryNav() {
 	.o-header-services__secondary-nav {
 		position: relative;

--- a/src/scss/_secondary-nav.scss
+++ b/src/scss/_secondary-nav.scss
@@ -27,21 +27,9 @@
 			position: relative;
 
 			a {
-				color: _oHeaderServicesGet('nav-text');
-				display: inline-block;
+				@include _oHeaderServicesHover($underline: true);
 				padding: 8px 0;
-				position: relative;
-
-				&:hover:after,
-				&[aria-current=true]:after {
-					content: '';
-					position: absolute;
-					bottom: 0;
-					left: 0;
-					width: 100%;
-					height: oTypographySpacingSize(1);
-					background-color: _oHeaderServicesGet('nav-text');
-				}
+				margin: 0;
 			}
 		}
 	}
@@ -88,6 +76,7 @@
 			border-left: 1px solid _oHeaderServicesGet('nav-border');
 		}
 	}
+
 	.o-header-services__scroll-button {
 		@include oButtonsTheme($theme: $_o-header-services-button-theme);
 		border: 1px solid _oHeaderServicesGet('nav-border');

--- a/src/scss/_theme.scss
+++ b/src/scss/_theme.scss
@@ -1,7 +1,7 @@
 /// @brand master
+/// @access private
 /// @param {String} $theme either b2b or b2c
 /// @outputs Changes navigation colours based on $theme
-/// @access private
 @mixin _oHeaderServicesTheme($theme) {
 	@if type-of($theme) != 'string' {
 		@error 'oHeaderServicesTheme `$theme` must be a string but "#{$theme}" is of type "#{type-of($theme)}".';

--- a/src/scss/_top.scss
+++ b/src/scss/_top.scss
@@ -104,7 +104,7 @@
 
 				@if _oHeaderServicesGet('underline-hover') {
 					&:hover:after {
-						content: unset;
+						content: none;
 					}
 				}
 

--- a/src/scss/_top.scss
+++ b/src/scss/_top.scss
@@ -1,6 +1,6 @@
-/// Styling for title section of header
-/// @param {String} $logo [ft-logo depending on brand (pink or white)]
 /// @access private
+/// @param {String} $logo [ft-logo depending on brand (pink or white)]
+/// @outputs styling for title section of header
 @mixin _oHeaderServicesTop($logo: $o-header-services-default-logo) {
 	.o-header-services__top {
 		@include oGridContainer;
@@ -66,8 +66,6 @@
 		}
 	}
 
-
-
 	.o-header-services__product-name {
 		@include oTypographySize($scale: 4);
 		@include oTypographyBold('sans');
@@ -80,7 +78,7 @@
 
 	.o-header-services__product-tagline {
 		@include oTypographySize($scale: 3);
-		margin-left: $_o-header-services-padding-x;
+		margin-left: $_o-header-services-padding;
 		text-overflow: ellipsis;
 		overflow: hidden;
 
@@ -91,7 +89,7 @@
 
 	.o-header-services__related-content {
 		margin: 0 0 0 auto;
-		padding: 16px $_o-header-services-padding-x;
+		padding: 16px $_o-header-services-padding;
 		display: flex;
 
 		li {
@@ -99,7 +97,7 @@
 
 			a {
 				@include oTypographyBold('sans');
-				margin: 0 $_o-header-services-padding-x;
+				margin: 0 $_o-header-services-padding;
 				color: _oHeaderServicesGet('top-text');
 
 				@if _oHeaderServicesGet('underline-hover') {
@@ -110,7 +108,7 @@
 
 				@include oGridRespondTo($until: M) {
 					display: block;
-					padding: $_o-header-services-padding-x $_o-header-services-padding-x*2;
+					padding: $_o-header-services-padding $_o-header-services-padding*2;
 					margin: 0;
 				}
 
@@ -120,5 +118,4 @@
 			}
 		}
 	}
-
 };

--- a/src/scss/_top.scss
+++ b/src/scss/_top.scss
@@ -16,19 +16,30 @@
 		}
 	}
 
-	.o-header-services__logo {
-		background-image: url('https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1:#{$logo}?source=o-header-services&format=svg&width=55');
-		background-repeat: no-repeat;
-		background-size: contain;
-		background-position: 0;
-		margin: 0;
-		height: $_o-header-services-top-bar-short;
-		width: $_o-header-services-top-bar-short;
+	.o-header-services__title {
+		display: flex;
+		align-items: center;
+	}
 
-		@include oGridRespondTo(M) {
-			margin: 8px 8px 8px 0;
-			height: $_o-header-services-top-icon-size;
-			width: $_o-header-services-top-icon-size;
+	@if _oHeaderServicesGet('logo') {
+		.o-header-services__logo {
+			background-image: url('https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1:#{$logo}?source=o-header-services&format=svg&width=55');
+			background-repeat: no-repeat;
+			background-size: contain;
+			background-position: 0;
+			margin: 0;
+			height: $_o-header-services-top-bar-short;
+			width: $_o-header-services-top-bar-short;
+
+			@include oGridRespondTo(M) {
+				margin: 8px 8px 8px 0;
+				height: $_o-header-services-top-icon-size;
+				width: $_o-header-services-top-icon-size;
+			}
+		}
+
+		.o-header-services__title {
+			padding-left: 10px;
 		}
 	}
 
@@ -55,11 +66,7 @@
 		}
 	}
 
-	.o-header-services__title {
-		display: flex;
-		align-items: center;
-		padding-left: 10px;
-	}
+
 
 	.o-header-services__product-name {
 		@include oTypographySize($scale: 4);
@@ -94,6 +101,12 @@
 				@include oTypographyBold('sans');
 				margin: 0 $_o-header-services-padding-x;
 				color: _oHeaderServicesGet('top-text');
+
+				@if _oHeaderServicesGet('underline-hover') {
+					&:hover:after {
+						content: unset;
+					}
+				}
 
 				@include oGridRespondTo($until: M) {
 					display: block;

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,7 +1,6 @@
 $o-header-services-is-silent: true !default;
 
-$_o-header-services-padding-x: oGridGutter();
-$_o-header-services-padding-y: oGridGutter();
+$_o-header-services-padding: oGridGutter();
 
 $_o-header-services-top-bar-short: oTypographySpacingSize(11);
 $_o-header-services-top-bar-z-index: 2;


### PR DESCRIPTION
After having a conversation with Tom Dew, who is working on FDi, and seeing his implementation of a header, this PR adds whitelabel specific support (which was missing anyway). 

It looks like this:

<img width="895" alt="screenshot 2019-01-15 at 09 01 30" src="https://user-images.githubusercontent.com/16777943/51169920-055a8680-18a5-11e9-9eea-9159953e667e.png">

<img width="393" alt="screenshot 2019-01-15 at 09 03 12" src="https://user-images.githubusercontent.com/16777943/51169922-055a8680-18a5-11e9-9488-99372bd59527.png">


Again,  README + MIGRATION are left for last when V3 is ready