### PR TITLE
Documentation & customisation update

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,10 +2,26 @@
 
 ### Migrating from v2 to v3
 
-V2 introduces many new changes to o-header-services. It now uses the primary nav as a drawer menu on smaller viewports. It removes a large dependency on o-header, and changes multiple class names and markup.
-It also removes most public mixins, and introduces a single public mixin, `oHeaderServices`;
+V2 introduces many new changes to o-header-services; It now transforms the primary nav into a drawer menu on smaller viewports. It introduces the option to have dropdown menus on primary navigation items. It removes a large dependency on o-header, and changes multiple class names and markup, and no longer allows custom class names. This major also removes most public mixins and makes `oHeaderServices` publicly available instead;
 <!-- private mixins here -->
-The markup for a full header has changed in the following way:
+```diff
+-oHeaderServicesContainer
++_oHeaderServicesBase
++_oHeaderServicesHover
+-oHeaderServicesPrimaryNav
++_oHeaderServicesPrimaryNav
++_oHeaderServicesDropDown
+-oHeaderServicesDrawer
++_oHeaderServicesDrawer
+-oHeaderServicesSubNav
++_oHeaderServicesSecondaryNav
+-oHeaderServicesTop
++_oHeaderServicesTop
+-oHeaderServicesTheme
++_oHeaderServicesTheme
+```
+
+The markup for a full header (**not** including dropdown menus) has changed in the following way:
 ```diff
 -<header class="o-header-services" data-o-component="o-header">
 +<header class='o-header-services' data-o-component='o-header-services'>
@@ -19,7 +35,8 @@ The markup for a full header has changed in the following way:
 		</div>
 		<div class='o-header-services__logo'></div>
 		<div class='o-header-services__title'>
-			<h1 class='o-header-services__product-name'><a href=''>Tool or Service name</a></h1>
+-			<a class='o-header-services__product-name' href=''>Tool or Service name</a>
++			<h1 class='o-header-services__product-name'><a href=''>Tool or Service name</a></h1>
 -				<span class='o-header-subrand__product-tagline'>Tagline to explain the product here</span>
 +				<span class='o-header-services__product-tagline'>Tagline to explain the product here</span>
 		</div>

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ You can be more selective about which types you would like to output, by using a
 
 
 To use a logo that is **not** the FT logo, the logo can be modified in one of two ways:
-- By using a logo name from the logo image set (e.g. 'Origami')
-- By passing in a full url or data url that points at the svg you want to use as a logo. Bear in mind that you can also run your chosen svg through the [Image Service's URL Builder](https://www.ft.com/__origami/service/image/v2/docs/url-builder), which will optimise the image and provide a URL for it.
+- By using a logo name from the logo image set (e.g. 'origami')
+- By passing in a full url or data url that points at the SVG you want to use as a logo (e.g. 'https://www.example.com/logo.svg'). Bear in mind that you can also run your chosen SVG through the [Image Service's URL Builder](https://www.ft.com/__origami/service/image/v2/docs/url-builder), which will optimise the image and provide a URL for it.
 
 In this example we include only the styles for a [primary navigation](#primary-navigation) with the [bleed modifier](#bleed-header). We opt to use the Origami logo from the [logo image set](https://registry.origami.ft.com/components/logo-images@1.8.0).
 
@@ -145,7 +145,7 @@ In this example we include only the styles for a [primary navigation](#primary-n
 );
 ```
 
-You can see all of the variables that are available for customising under `whitelabel` in `../src/scss/_brand.scss`.
+You can see all of the variables that are available for customising under `whitelabel` in the [brand SCSS file](../src/scss/_brand.scss#L70).
 
 ## JavaScript
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ This header is for tools and services built by the Financial Times.
 - [Markup](#markup)
 	- [Title Section](#title-section)
 	- [Primary navigation](#primary-navigation)
+	- [Primary navigation with drop down](#primary-navigation-with-drop-down)
 	- [Secondary navigation](#secondary-navigation)
 	- [Themes](#themes)
 	- [Bleed header](#bleed-header)
 - [Sass](#sass)
+	- [Customisation](#customisation)
 - [JavaScript](#javascript)
 - [Migration](#migration)
 - [Contact](#contact)
@@ -43,18 +45,26 @@ This section of the header has specific behaviour, as it turns into a drawer at 
 
 If you are using extra content (such as a 'Sign in' link), that will be pulled into the drawer, as well.
 
-You can see an example, with markup, of the [primary navigation in the Origami Registry](https://registry.origami.ft.com/components/o-header-services#demo-primary-navigation).
+For an example and markup, see the [primary navigation in the Origami Registry](https://registry.origami.ft.com/components/o-header-services#demo-primary-navigation).
+
+### Primary Navigation with drop down
+
+The primary navigation can also handle dropdown menus. These menus are hidden behind a button that lives beside the navigation item that it is pertinent to.
+
+Drop down menus also get pulled into the drawer on smaller viewports.
+
+For an example and markup, see the [primary navigation with drop downs in the Origami Registry](https://registry.origami.ft.com/components/o-header-services#demo-drop-down-navigation).
 
 ### Secondary Navigation
 
 The secondary navigation is also an **optional** addition to the header, but it makes more sense alongside the primary navigation, as it serves more complicated products.
 
-It includes two sections  of navigation, 'ancestors' and 'children'.
+It includes two sections of navigation: 'ancestors' and 'children'.
 The 'ancestor' section  works in the form of a breadcrumb, and the children are relative to the ancestor.
 
-At smaller viewports, it does _not_ collapse into the drawer, but becomes scrollable, instead.
+At smaller viewports, it does _not_ collapse into the drawer, but becomes scrollable instead.
 
-You can see an example, with markup, of the [secondary navigation in the Origami Registry](https://registry.origami.ft.com/components/o-header-services#demo-secondary-navigation).
+For an example and markup, see the [secondary navigation in the Origami Registry](https://registry.origami.ft.com/components/o-header-services#demo-secondary-navigation).
 
 ### Themes
 
@@ -69,7 +79,7 @@ To add a theme to the header, add the appropriate class to the header element. F
 </header>
 ```
 
-You can preview [B2B and B2C headers in the Origami Registry](https://registry.origami.ft.com/components/o-header-services#demo-theme-b2c).
+For an example and markup, see the [B2B and B2C headers in the Origami Registry](https://registry.origami.ft.com/components/o-header-services#demo-theme-b2c).
 
 ### Bleed Header
 If your application requires a bleed header, you'll need to add the `o-header-services--bleed` variant to your header.
@@ -112,6 +122,24 @@ In this example we include only the styles for a [primary navigation](#primary-n
 
 	// Will output styles for a bleed header with a primary navigation and the Origami logo
 ```
+### Customisation
+
+`o-header-services` provides the option to customise the `whitelabel` brand. If you are using this brand, you can modify brand-specific variables by overriding them in a map in `oHeaderServicesCustomize`.
+
+```scss
+@import 'o-header-services/main';
+
+@include oHeaderServicesCustomize((
+	'nav-hover-background': '#FF69B4' // will apply to background colors on hover, where appropriate
+))
+
+@include oHeaderServices($opts:
+	'types': ('primary-nav'),
+	'features': ('drop-dowm')
+);
+```
+
+You can see all of the variables that are available for customising under `whitelabel` in `../src/scss/_brand.scss`.
 
 ## JavaScript
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,13 @@ You can be more selective about which types you would like to output, by using a
 **logo**
 - the name of a logo from the [logos image set](https://registry.origami.ft.com/components/logo-images@1.8.0). Defaults to the FT logo.
 
+
+To use a logo that is **not** the FT logo, the logo can be modified in one of two ways:
+- By using a logo name from the logo image set (e.g. 'Origami')
+- By passing in a full url or data url that points at the svg you want to use as a logo. Bear in mind that you can also run your chosen svg through the [Image Service's URL Builder](https://www.ft.com/__origami/service/image/v2/docs/url-builder), which will optimise the image and provide a URL for it.
+
 In this example we include only the styles for a [primary navigation](#primary-navigation) with the [bleed modifier](#bleed-header). We opt to use the Origami logo from the [logo image set](https://registry.origami.ft.com/components/logo-images@1.8.0).
+
 ```scss
 	@import 'o-header-services/main';
 

--- a/demos/src/header.mustache
+++ b/demos/src/header.mustache
@@ -25,8 +25,8 @@
 	{{#primary-navigation}}
 	<nav class="o-header-services__primary-nav" aria-label="primary">
 		<ul class="o-header-services__primary-nav-list">
-			<li data-o-header-services-level="1">
-				<a aria-current="true" href="{{href}}">Docs</a><!--
+			<li {{#drop-down}}data-o-header-services-level="1"{{/drop-down}}>
+				<a aria-current="true" href="{{href}}">Docs</a>{{#drop-down}}<!--
 				--><button class="o-header-services__drop-down-button" type="button" name="button" aria-label="Toggle dropdown menu"></button>
 				<ul data-o-header-services-level="2" aria-hidden="true">
 					<li>
@@ -42,10 +42,10 @@
 						<a href="{{href}}">Tutorials</a>
 					</li>
 					<button class="o-header-services__visually-hidden" type="button" name="button">Close dropdown menu</button>
-				</ul>
+				</ul>{{/drop-down}}
 			</li>
-			<li data-o-header-services-level="1">
-				<a href="{{href}}">Specs</a><!--
+			<li {{#drop-down}}data-o-header-services-level="1"{{/drop-down}}>
+				<a href="{{href}}">Specs</a>{{#drop-down}}<!--
 				--><button class="o-header-services__drop-down-button" type="button" name="button" aria-label="Toggle dropdown menu"></button>
 				<ul data-o-header-services-level="2" aria-hidden="true">
 					<li>
@@ -64,7 +64,7 @@
 						<a href="{{href}}">Manifest</a>
 					</li>
 					<button class="o-header-services__visually-hidden" type="button" name="button">Close dropdown menu</button>
-				</ul>
+				</ul>{{/drop-down}}
 			</li>
 			<li>
 				<a href="#">Registry</a>

--- a/demos/src/header.mustache
+++ b/demos/src/header.mustache
@@ -9,7 +9,7 @@
 			{{/primary-navigation}}
 		<div class="o-header-services__logo"></div>
 		<div class="o-header-services__title">
-			<a class="o-header-services__product-name" href="/">Tool or Service name</a>
+			<h1 class="o-header-services__product-name"><a href="/">Tool or Service name</a></h1>
 			<span class="o-header-services__product-tagline">Tagline to explain the product here</span>
 		</div>
 		<ul class="o-header-services__related-content">

--- a/main.scss
+++ b/main.scss
@@ -11,6 +11,7 @@
 @import 'src/scss/variables';
 @import 'src/scss/drawer';
 @import 'src/scss/drop-down';
+@import 'src/scss/functions';
 @import 'src/scss/top';
 @import 'src/scss/theme';
 @import 'src/scss/primary-nav';
@@ -26,6 +27,7 @@
 )) {
 	$types: map-get($opts, 'types');
 	$features: map-get($opts, 'features');
+	$logo: map-get($opts, 'logo');
 
 	$bleed: index($features, 'bleed');
 
@@ -34,7 +36,7 @@
 
 	/// Required because there would be no header without the title
 	/// if other features aren't added.
-	@include _oHeaderServicesTop($logo: map-get($opts, 'logo'));
+	@include _oHeaderServicesTop($logo);
 
 	@if index($types, 'primary-nav') {
 		@include _oHeaderServicesPrimaryNav;

--- a/origami.json
+++ b/origami.json
@@ -46,6 +46,15 @@
 			}
 		},
 		{
+			"name": "drop-down-navigation",
+			"title": "Header with primary navigation and drop down menus",
+			"description": "Navigation for an overview of a product's pages. These nav items collapse into a drawer at narrow screen widths, and can be presented as dropdown menus",
+			"data": {
+				"primary-navigation": true,
+				"drop-down": true
+			}
+		},
+		{
 			"name": "secondary-navigation",
 			"title": "Header with a primary and a secondary navigation",
 			"description": "For sites with more than a few sections, a secondary navigation is also available",

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -1,0 +1,7 @@
+@function _oHeaderServicesLogo($logo) {
+	@if str-index($logo, 'https') or str-index($logo, 'http') or str-index($logo, 'data') {
+		@return $logo;
+	} @else {
+		@return 'https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1:#{$logo}?source=o-header-services&format=svg&width=55';
+	}
+}

--- a/src/scss/_top.scss
+++ b/src/scss/_top.scss
@@ -1,7 +1,7 @@
 /// @access private
 /// @param {String} $logo [ft-logo depending on brand (pink or white)]
 /// @outputs styling for title section of header
-@mixin _oHeaderServicesTop($logo: _oHeaderServicesGet('logo')) {
+@mixin _oHeaderServicesTop($logo) {
 	.o-header-services__top {
 		@include oGridContainer;
 		background-color: _oHeaderServicesGet('top-background');
@@ -21,9 +21,13 @@
 		align-items: center;
 	}
 
+	.o-header-services__product-name {
+		margin: 0;
+	}
+
 	@if $logo {
 		.o-header-services__logo {
-			background-image: url('https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1:#{$logo}?source=o-header-services&format=svg&width=55');
+			background-image: url(_oHeaderServicesLogo($logo));
 			background-repeat: no-repeat;
 			background-size: contain;
 			background-position: 0;


### PR DESCRIPTION
Last but not least, this PR updates the README and the MIGRATION.md

It also makes a change to the way in which the logo is implemented, allowing for a string with the logo name or a full url to be passed in to the primary mixin's `$opts`.