### PR TITLE
Enable relative url support for custom logos

### DIFF
--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -1,5 +1,5 @@
 @function _oHeaderServicesLogo($logo) {
-	@if str-index($logo, 'https://') == 0 or str-index($logo, 'http://') == 0 or str-index($logo, 'data:') == 0 or str-index($logo, './') == 0 or str-index($logo, '/') == 0 {
+	@if str-index($logo, 'https://') == 1 or str-index($logo, 'http://') == 1 or str-index($logo, 'data:') == 1 or str-index($logo, './') == 0 or str-index($logo, '/') == 1 {
 		@return $logo;
 	} @else {
 		@return 'https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1:#{$logo}?source=o-header-services&format=svg&width=55';

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -1,5 +1,5 @@
 @function _oHeaderServicesLogo($logo) {
-	@if str-index($logo, 'https') or str-index($logo, 'http') or str-index($logo, 'data') {
+	@if str-index($logo, 'https') == 0 or str-index($logo, 'http') == 0 or str-index($logo, 'data') == 0 or str-index($logo, './') == 0 or str-index($logo, '/') == 0 {
 		@return $logo;
 	} @else {
 		@return 'https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1:#{$logo}?source=o-header-services&format=svg&width=55';

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -1,5 +1,5 @@
 @function _oHeaderServicesLogo($logo) {
-	@if str-index($logo, 'https') == 0 or str-index($logo, 'http') == 0 or str-index($logo, 'data') == 0 or str-index($logo, './') == 0 or str-index($logo, '/') == 0 {
+	@if str-index($logo, 'https://') == 0 or str-index($logo, 'http://') == 0 or str-index($logo, 'data:') == 0 or str-index($logo, './') == 0 or str-index($logo, '/') == 0 {
 		@return $logo;
 	} @else {
 		@return 'https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1:#{$logo}?source=o-header-services&format=svg&width=55';


### PR DESCRIPTION
This allows a user of o-header-services to use url-relative paths for their logo. This feature was requested by the Origami team for use on the polyfill.io service.