### PR TITLE
Update brand configuration and drawer design

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,22 +3,13 @@
 ### Migrating from v2 to v3
 
 V2 introduces many new changes to o-header-services; It now transforms the primary nav into a drawer menu on smaller viewports. It introduces the option to have dropdown menus on primary navigation items. It removes a large dependency on o-header, and changes multiple class names and markup, and no longer allows custom class names. This major also removes most public mixins and makes `oHeaderServices` publicly available instead;
-<!-- private mixins here -->
 ```diff
 -oHeaderServicesContainer
-+_oHeaderServicesBase
-+_oHeaderServicesHover
 -oHeaderServicesPrimaryNav
-+_oHeaderServicesPrimaryNav
-+_oHeaderServicesDropDown
 -oHeaderServicesDrawer
-+_oHeaderServicesDrawer
 -oHeaderServicesSubNav
-+_oHeaderServicesSecondaryNav
 -oHeaderServicesTop
-+_oHeaderServicesTop
 -oHeaderServicesTheme
-+_oHeaderServicesTheme
 ```
 
 The markup for a full header (**not** including dropdown menus) has changed in the following way:

--- a/README.md
+++ b/README.md
@@ -109,7 +109,10 @@ You can be more selective about which types you would like to output, by using a
 - `'b2c'`
 
 **logo**
-- the name of a logo from the [logos image set](https://registry.origami.ft.com/components/logo-images@1.8.0). Defaults to the FT logo.
+- The name of a logo from the [logos image set](https://registry.origami.ft.com/components/logo-images@1.8.0). Defaults to the FT logo.
+
+**drawer-breakpoint**
+- The breakpoint to move the primary navigation into a drawer. We recommend a `rem` value or a layout size from [o-grid](https://github.com/Financial-Times/o-grid/#layout-sizes) e.g. 'M'. Defaults to the medium grid size 'M'.
 
 
 To use a logo that is **not** the FT logo, the logo can be modified in one of two ways:

--- a/demos/src/header.mustache
+++ b/demos/src/header.mustache
@@ -26,11 +26,8 @@
 	{{#primary-navigation}}
 	<nav class="o-header-services__primary-nav" aria-label="primary">
 		<ul class="o-header-services__primary-nav-list">
-			<li>
-				<a href="{{href}}">Home</a>
-			</li>
 			<li {{#drop-down}}data-o-header-services-level="1"{{/drop-down}}>
-				<a aria-current="true" href="{{href}}">News</a>{{#drop-down}}<!--
+				<a aria-current="true" href="{{href}}">Docs</a>{{#drop-down}}<!--
 				--><button class="o-header-services__drop-down-button" type="button" name="button" aria-label="Toggle dropdown menu"></button>
 				<ul data-o-header-services-level="2" aria-hidden="true">
 					<li>
@@ -49,73 +46,7 @@
 				</ul>{{/drop-down}}
 			</li>
 			<li {{#drop-down}}data-o-header-services-level="1"{{/drop-down}}>
-				<a href="{{href}}">Research Locations</a>{{#drop-down}}<!--
-				--><button class="o-header-services__drop-down-button" type="button" name="button" aria-label="Toggle dropdown menu"></button>
-				<ul data-o-header-services-level="2" aria-hidden="true">
-					<li>
-						<a href="{{href}}">Condensed Spec</a>
-					</li>
-					<li>
-						<a href="{{href}}">Formal Spec</a>
-					</li>
-					<li>
-						<a href="{{href}}">Components</a>
-					</li>
-					<li>
-						<a href="{{href}}">Services</a>
-					</li>
-					<li>
-						<a href="{{href}}">Manifest</a>
-					</li>
-					<button class="o-header-services__visually-hidden" type="button" name="button">Close dropdown menu</button>
-				</ul>{{/drop-down}}
-			</li>
-			<li {{#drop-down}}data-o-header-services-level="1"{{/drop-down}}>
-				<a href="{{href}}">Promote Your Location</a>{{#drop-down}}<!--
-				--><button class="o-header-services__drop-down-button" type="button" name="button" aria-label="Toggle dropdown menu"></button>
-				<ul data-o-header-services-level="2" aria-hidden="true">
-					<li>
-						<a href="{{href}}">Condensed Spec</a>
-					</li>
-					<li>
-						<a href="{{href}}">Formal Spec</a>
-					</li>
-					<li>
-						<a href="{{href}}">Components</a>
-					</li>
-					<li>
-						<a href="{{href}}">Services</a>
-					</li>
-					<li>
-						<a href="{{href}}">Manifest</a>
-					</li>
-					<button class="o-header-services__visually-hidden" type="button" name="button">Close dropdown menu</button>
-				</ul>{{/drop-down}}
-			</li>
-			<li {{#drop-down}}data-o-header-services-level="1"{{/drop-down}}>
-				<a href="{{href}}">Generate Leads</a>{{#drop-down}}<!--
-				--><button class="o-header-services__drop-down-button" type="button" name="button" aria-label="Toggle dropdown menu"></button>
-				<ul data-o-header-services-level="2" aria-hidden="true">
-					<li>
-						<a href="{{href}}">Condensed Spec</a>
-					</li>
-					<li>
-						<a href="{{href}}">Formal Spec</a>
-					</li>
-					<li>
-						<a href="{{href}}">Components</a>
-					</li>
-					<li>
-						<a href="{{href}}">Services</a>
-					</li>
-					<li>
-						<a href="{{href}}">Manifest</a>
-					</li>
-					<button class="o-header-services__visually-hidden" type="button" name="button">Close dropdown menu</button>
-				</ul>{{/drop-down}}
-			</li>
-			<li {{#drop-down}}data-o-header-services-level="1"{{/drop-down}}>
-				<a href="{{href}}">Events</a>{{#drop-down}}<!--
+				<a href="{{href}}">Specs</a>{{#drop-down}}<!--
 				--><button class="o-header-services__drop-down-button" type="button" name="button" aria-label="Toggle dropdown menu"></button>
 				<ul data-o-header-services-level="2" aria-hidden="true">
 					<li>
@@ -137,7 +68,7 @@
 				</ul>{{/drop-down}}
 			</li>
 			<li>
-				<a href="#">Products &amp; Services</a>
+				<a href="#">Registry</a>
 			</li>
 		</ul>
 	</nav>

--- a/demos/src/header.mustache
+++ b/demos/src/header.mustache
@@ -1,3 +1,4 @@
+
 <header class="o-header-services {{#modifier}}o-header-services--{{modifier}}{{/modifier}}" data-o-component="o-header-services">
 	<div class="o-header-services__top">
 			{{#primary-navigation}}

--- a/demos/src/header.mustache
+++ b/demos/src/header.mustache
@@ -26,8 +26,11 @@
 	{{#primary-navigation}}
 	<nav class="o-header-services__primary-nav" aria-label="primary">
 		<ul class="o-header-services__primary-nav-list">
+			<li>
+				<a href="{{href}}">Home</a>
+			</li>
 			<li {{#drop-down}}data-o-header-services-level="1"{{/drop-down}}>
-				<a aria-current="true" href="{{href}}">Docs</a>{{#drop-down}}<!--
+				<a aria-current="true" href="{{href}}">News</a>{{#drop-down}}<!--
 				--><button class="o-header-services__drop-down-button" type="button" name="button" aria-label="Toggle dropdown menu"></button>
 				<ul data-o-header-services-level="2" aria-hidden="true">
 					<li>
@@ -46,7 +49,73 @@
 				</ul>{{/drop-down}}
 			</li>
 			<li {{#drop-down}}data-o-header-services-level="1"{{/drop-down}}>
-				<a href="{{href}}">Specs</a>{{#drop-down}}<!--
+				<a href="{{href}}">Research Locations</a>{{#drop-down}}<!--
+				--><button class="o-header-services__drop-down-button" type="button" name="button" aria-label="Toggle dropdown menu"></button>
+				<ul data-o-header-services-level="2" aria-hidden="true">
+					<li>
+						<a href="{{href}}">Condensed Spec</a>
+					</li>
+					<li>
+						<a href="{{href}}">Formal Spec</a>
+					</li>
+					<li>
+						<a href="{{href}}">Components</a>
+					</li>
+					<li>
+						<a href="{{href}}">Services</a>
+					</li>
+					<li>
+						<a href="{{href}}">Manifest</a>
+					</li>
+					<button class="o-header-services__visually-hidden" type="button" name="button">Close dropdown menu</button>
+				</ul>{{/drop-down}}
+			</li>
+			<li {{#drop-down}}data-o-header-services-level="1"{{/drop-down}}>
+				<a href="{{href}}">Promote Your Location</a>{{#drop-down}}<!--
+				--><button class="o-header-services__drop-down-button" type="button" name="button" aria-label="Toggle dropdown menu"></button>
+				<ul data-o-header-services-level="2" aria-hidden="true">
+					<li>
+						<a href="{{href}}">Condensed Spec</a>
+					</li>
+					<li>
+						<a href="{{href}}">Formal Spec</a>
+					</li>
+					<li>
+						<a href="{{href}}">Components</a>
+					</li>
+					<li>
+						<a href="{{href}}">Services</a>
+					</li>
+					<li>
+						<a href="{{href}}">Manifest</a>
+					</li>
+					<button class="o-header-services__visually-hidden" type="button" name="button">Close dropdown menu</button>
+				</ul>{{/drop-down}}
+			</li>
+			<li {{#drop-down}}data-o-header-services-level="1"{{/drop-down}}>
+				<a href="{{href}}">Generate Leads</a>{{#drop-down}}<!--
+				--><button class="o-header-services__drop-down-button" type="button" name="button" aria-label="Toggle dropdown menu"></button>
+				<ul data-o-header-services-level="2" aria-hidden="true">
+					<li>
+						<a href="{{href}}">Condensed Spec</a>
+					</li>
+					<li>
+						<a href="{{href}}">Formal Spec</a>
+					</li>
+					<li>
+						<a href="{{href}}">Components</a>
+					</li>
+					<li>
+						<a href="{{href}}">Services</a>
+					</li>
+					<li>
+						<a href="{{href}}">Manifest</a>
+					</li>
+					<button class="o-header-services__visually-hidden" type="button" name="button">Close dropdown menu</button>
+				</ul>{{/drop-down}}
+			</li>
+			<li {{#drop-down}}data-o-header-services-level="1"{{/drop-down}}>
+				<a href="{{href}}">Events</a>{{#drop-down}}<!--
 				--><button class="o-header-services__drop-down-button" type="button" name="button" aria-label="Toggle dropdown menu"></button>
 				<ul data-o-header-services-level="2" aria-hidden="true">
 					<li>
@@ -68,7 +137,7 @@
 				</ul>{{/drop-down}}
 			</li>
 			<li>
-				<a href="#">Registry</a>
+				<a href="#">Products &amp; Services</a>
 			</li>
 		</ul>
 	</nav>

--- a/main.scss
+++ b/main.scss
@@ -52,7 +52,7 @@
 	}
 
 	@if index($types, 'secondary-nav') {
-		@include _oHeaderServicesSecondaryNav;
+		@include _oHeaderServicesSecondaryNav($drawer-breakpoint);
 	}
 
 	@if index($types, 'b2b') and _oHeaderSupports('b2b') {

--- a/main.scss
+++ b/main.scss
@@ -29,11 +29,13 @@
 @mixin oHeaderServices($opts: (
 	'types': ('primary-nav', 'secondary-nav', 'b2b', 'b2c'),
 	'features': ('bleed', 'drop-down'),
-	'logo': _oHeaderServicesGet('logo')
+	'logo': _oHeaderServicesGet('logo'),
+	'drawer-breakpoint': 'M'
 )) {
 	$types: map-get($opts, 'types');
 	$features: map-get($opts, 'features');
 	$logo: map-get($opts, 'logo');
+	$drawer-breakpoint: if(map-get($opts, 'drawer-breakpoint'), map-get($opts, 'drawer-breakpoint'), 'M');
 
 	$bleed: index($features, 'bleed');
 	$drop-down: index($features, 'drop-down');
@@ -43,7 +45,7 @@
 
 	/// Required because there would be no header without the title
 	/// if other features aren't added.
-	@include _oHeaderServicesTop($logo);
+	@include _oHeaderServicesTop($logo, $drawer-breakpoint);
 
 	@if index($types, 'primary-nav') {
 		@include _oHeaderServicesPrimaryNav($drop-down);

--- a/main.scss
+++ b/main.scss
@@ -36,6 +36,7 @@
 	$logo: map-get($opts, 'logo');
 
 	$bleed: index($features, 'bleed');
+	$drop-down: index($features, 'drop-down');
 
 	/// Base styles for a header
 	@include _oHeaderServicesBase($bleed);
@@ -45,7 +46,7 @@
 	@include _oHeaderServicesTop($logo);
 
 	@if index($types, 'primary-nav') {
-		@include _oHeaderServicesPrimaryNav;
+		@include _oHeaderServicesPrimaryNav($drop-down);
 	}
 
 	@if index($types, 'secondary-nav') {
@@ -60,7 +61,7 @@
 		@include _oHeaderServicesTheme($theme: 'b2c');
 	}
 
-	@if index($features, 'drop-down') {
+	@if $drop-down {
 		@include _oHeaderServicesDropDown();
 	}
 }

--- a/origami.json
+++ b/origami.json
@@ -51,7 +51,6 @@
 			"title": "Header with primary navigation and drop down menus",
 			"description": "Navigation for an overview of a product's pages. These nav items collapse into a drawer at narrow screen widths, and can be presented as dropdown menus",
 			"data": {
-				"fake-ad": true,
 				"primary-navigation": true,
 				"drop-down": true,
 				"sub-navigation": true

--- a/origami.json
+++ b/origami.json
@@ -51,8 +51,10 @@
 			"title": "Header with primary navigation and drop down menus",
 			"description": "Navigation for an overview of a product's pages. These nav items collapse into a drawer at narrow screen widths, and can be presented as dropdown menus",
 			"data": {
+				"fake-ad": true,
 				"primary-navigation": true,
-				"drop-down": true
+				"drop-down": true,
+				"sub-navigation": true
 			}
 		},
 		{

--- a/src/js/drawer.js
+++ b/src/js/drawer.js
@@ -9,12 +9,30 @@ class Drawer {
 	constructor(headerEl) {
 		this.headerEl = headerEl;
 		this.nav = headerEl.querySelector('.o-header-services__primary-nav');
+		this.navList = this.nav.querySelector('.o-header-services__primary-nav-list');
 		this.class = {
 			drawer: 'o-header-services__primary-nav--drawer',
 			open: 'o-header-services__primary-nav--open'
 		};
 
 		if (!this.nav) { return; }
+
+
+		// Create drawer header.
+		let drawerHeader = document.createElement('li');
+		drawerHeader.classList.add('o-header-services__drawer-header');
+		this.drawerCloseButton = document.createElement('button');
+		this.drawerCloseButton.classList.add('o-header-services__drawer-close-button');
+		this.drawerCloseButton.innerText = 'Close';
+		// Add drawer header to navlist, with close button.
+		if (this.navList) {
+			drawerHeader.appendChild(this.drawerCloseButton);
+			if (this.navList && this.navList.firstChild) {
+				this.navList.insertBefore(drawerHeader, this.navList.firstChild);
+			} else {
+				this.navList.appendChild(drawerHeader);
+			}
+		}
 
 		this.debouncedRender = oUtils.debounce(() => this.render(), 100);
 		this.burger = this.headerEl.querySelector('.o-header-services__hamburger-icon');
@@ -32,12 +50,16 @@ class Drawer {
 	handleEvent(e) {
 		if (e.type === 'resize') {
 			this.debouncedRender();
-		} else if (e.type === 'keydown') {
+		}
+
+		if (e.type === 'keydown') {
 			if (e.key === 'Escape' && this.nav.classList.contains(this.class.open)) {
 				this.toggleDrawer();
 				this.burger.focus();
 			}
-		} else if (e.type === 'click' || e.type === 'focusout') {
+		}
+
+		if ((e.type === 'click' && [this.nav, this.burger, this.drawerCloseButton].includes(e.target))) {
 			this.toggleDrawer();
 		}
 	}
@@ -67,7 +89,13 @@ class Drawer {
 	toggleDrawer () {
 		this.nav.classList.toggle(this.class.open);
 		this.burger.classList.toggle('o-header-services__hambuger--open');
-		this._toggleAriaAttributes(this.nav.classList.contains(this.class.open));
+		const open = this.nav.classList.contains(this.class.open);
+		this._toggleAriaAttributes(open);
+		if (open) {
+			setTimeout(function(){
+				this.drawerCloseButton.focus();
+			}.bind(this), 50); // Wait for drawer to be open
+		}
 	}
 
 	/**
@@ -79,9 +107,8 @@ class Drawer {
 		if (!relatedContent) { return; }
 
 		let headerTop = this.headerEl.querySelector('.o-header-services__top');
-		let navList = this.nav.querySelector('.o-header-services__primary-nav-list');
 
-		return shiftItems ? navList.appendChild(relatedContent) : headerTop.appendChild(relatedContent);
+		return shiftItems ? this.navList.appendChild(relatedContent) : headerTop.appendChild(relatedContent);
 	}
 
 	/**

--- a/src/js/drawer.js
+++ b/src/js/drawer.js
@@ -1,4 +1,3 @@
-import oGrid from 'o-grid';
 import * as oUtils from 'o-utils';
 
 class Drawer {
@@ -9,7 +8,6 @@ class Drawer {
 	constructor(headerEl) {
 		this.headerEl = headerEl;
 		this.nav = headerEl.querySelector('.o-header-services__primary-nav');
-		this.navList = this.nav.querySelector('.o-header-services__primary-nav-list');
 		this.class = {
 			drawer: 'o-header-services__primary-nav--drawer',
 			open: 'o-header-services__primary-nav--open'
@@ -17,6 +15,7 @@ class Drawer {
 
 		if (!this.nav) { return; }
 
+		this.navList = this.nav.querySelector('.o-header-services__primary-nav-list');
 
 		// Create drawer header.
 		let drawerHeader = document.createElement('li');
@@ -68,7 +67,8 @@ class Drawer {
 	 * Drawer rendering
 	 */
 	render () {
-		const enableDrawer = oGrid.getCurrentLayout() === 'default' || oGrid.getCurrentLayout() === 'S';
+		// If burger is not hidden render the drawer.
+		const enableDrawer = this.burger.offsetParent !== null;
 
 		if (enableDrawer) {
 			this.nav.addEventListener('click', this);

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -17,19 +17,15 @@
 		ol,
 		ul {
 			list-style-type: none;
-
-			@include oGridRespondTo(S) {
-				white-space: nowrap;
-			};
-		}
-
-		.o-header-services__visually-hidden {
-			@include oNormaliseVisuallyHidden;
 		}
 	}
 
+	.o-header-services__visually-hidden {
+		@include oNormaliseVisuallyHidden;
+	}
+
 	@if $bleed {
-		.o-header-services--bleed {
+		.o-header-services.o-header-services--bleed {
 			.o-header-services__top,
 			.o-header-services__primary-nav-list,
 			.o-header-services__secondary-nav-content {
@@ -41,48 +37,6 @@
 			.o-header-services__primary-nav-list  {
 				padding: 0;
 			}
-		}
-	}
-}
-
-/// @access private
-/// @param {Boolean} $underline [whether or not to make the hover an underline or a background change]
-/// @outputs hover styles
-@mixin _oHeaderServicesHover($underline) {
-	color: _oHeaderServicesGet('nav-text');
-	position: relative;
-
-	&:hover {
-		color: _oHeaderServicesGet('text-hover-color');
-	}
-
-	@if $underline {
-		display: inline-block;
-		margin: 0 oTypographySpacingSize(5);
-		padding: $_o-header-services-padding 0;
-
-		&[aria-current=true] {
-			color: _oHeaderServicesGet('text-hover-color');
-		}
-
-		&:hover:before,
-		&[aria-current=true]:before {
-			content: '';
-			position: absolute;
-			bottom: 0;
-			left: 0;
-			width: 100%;
-			height: oTypographySpacingSize(1);
-			background-color: _oHeaderServicesGet('nav-underline-color');
-		}
-	} @else {
-		display: block;
-		margin: 0;
-		padding: $_o-header-services-padding  oTypographySpacingSize(5);
-
-		&:hover,
-		&[aria-current=true] {
-			background-color: _oHeaderServicesGet('nav-hover-background');
 		}
 	}
 }

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -8,6 +8,7 @@
 	.o-header-services {
 		@include oTypographySans($scale: 0);
 		background-color: _oHeaderServicesGet('top-background');
+		border-bottom: 1px solid _oHeaderServicesGet('nav-border');
 		-webkit-font-smoothing: antialiased; // sass-lint:disable-line no-vendor-prefixes
 
 		a {

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -33,7 +33,7 @@
 			.o-header-services__top,
 			.o-header-services__primary-nav-list,
 			.o-header-services__secondary-nav-content {
-				@include oGridContainer($bleed: $bleed)
+				@include oGridContainer($bleed: $bleed);
 				max-width: 100%;
 				padding: 0 oTypographySpacingSize(5);
 			}
@@ -52,10 +52,18 @@
 	color: _oHeaderServicesGet('nav-text');
 	position: relative;
 
+	&:hover {
+		color: _oHeaderServicesGet('text-hover-color');
+	}
+
 	@if $underline {
 		display: inline-block;
 		margin: 0 oTypographySpacingSize(5);
 		padding: $_o-header-services-padding 0;
+
+		&[aria-current=true] {
+			color: _oHeaderServicesGet('text-hover-color');
+		}
 
 		&:hover:before,
 		&[aria-current=true]:before {

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -56,7 +56,9 @@
 			'b2c'
 		)
 	));
-} @elseif oBrandGetCurrentBrand() == 'internal' {
+}
+
+@if oBrandGetCurrentBrand() == 'internal' {
 	@include oBrandDefine('o-header-services', 'internal', (
 		'variables': (
 			logo: 'brand-ft-logo-squared-bw',
@@ -72,7 +74,9 @@
 		),
 		'supports-variants': ()
 	));
-} @elseif oBrandGetCurrentBrand() == 'whitelabel' {
+}
+
+@if oBrandGetCurrentBrand() == 'whitelabel' {
 	@include oBrandDefine('o-header-services', 'whitelabel', (
 		'variables': (
 			logo: null,
@@ -90,3 +94,31 @@
 		'supports-variants': ()
 	));
 }
+
+// @if oBrandGetCurrentBrand() == 'whitelabel' {
+// 	$fdi-blue: #1173C1;
+// 	$background-grey: #ECECEC;
+// 	$fdi-border: #979797;
+// 	@include oBrandDefine('o-header-services', 'whitelabel', (
+// 		'variables': (
+// 			logo: null,
+// 			top-text: oColorsGetPaletteColor('white'),
+// 			top-background: oColorsGetPaletteColor('black'),
+// 			nav-text: oColorsGetPaletteColor('black'),
+// 			nav-background: oColorsGetPaletteColor('white'),
+// 			nav-border: $fdi-border,
+// 			nav-hover-background: $background-grey,
+// 			nav-underline-color: $fdi-blue,
+// 			arrow-icon-color: oColorsGetPaletteColor('black'),
+// 			arrow-icon-hover-color: $fdi-blue,
+// 			button-hover-color: $background-grey,
+// 			text-hover-color: $fdi-blue,
+
+// 			drawer-background: $background-grey,
+// 			drawer-button-background: darken($background-grey, 10),
+// 			drawer-text-hover-color: #FFFFFF,
+// 			drawer-nav-hover-background: $fdi-blue,
+// 		),
+// 		'supports-variants': ()
+// 	));
+// }

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -94,31 +94,3 @@
 		'supports-variants': ()
 	));
 }
-
-// @if oBrandGetCurrentBrand() == 'whitelabel' {
-// 	$fdi-blue: #1173C1;
-// 	$background-grey: #ECECEC;
-// 	$fdi-border: #979797;
-// 	@include oBrandDefine('o-header-services', 'whitelabel', (
-// 		'variables': (
-// 			logo: null,
-// 			top-text: oColorsGetPaletteColor('white'),
-// 			top-background: oColorsGetPaletteColor('black'),
-// 			nav-text: oColorsGetPaletteColor('black'),
-// 			nav-background: oColorsGetPaletteColor('white'),
-// 			nav-border: $fdi-border,
-// 			nav-hover-background: $background-grey,
-// 			nav-underline-color: $fdi-blue,
-// 			arrow-icon-color: oColorsGetPaletteColor('black'),
-// 			arrow-icon-hover-color: $fdi-blue,
-// 			button-hover-color: $background-grey,
-// 			text-hover-color: $fdi-blue,
-
-// 			drawer-background: $background-grey,
-// 			drawer-button-background: darken($background-grey, 10),
-// 			drawer-text-hover-color: #FFFFFF,
-// 			drawer-nav-hover-background: $fdi-blue,
-// 		),
-// 		'supports-variants': ()
-// 	));
-// }

--- a/src/scss/_drawer.scss
+++ b/src/scss/_drawer.scss
@@ -1,10 +1,85 @@
 /// @access private
 /// @outputs styling for the drawer
 @mixin _oHeaderServicesDrawer {
-	.o-header-services__primary-nav--drawer {
-		background-color: rgba(0, 0, 0, 0.2);
-		position: absolute;
-		top: $_o-header-services-top-bar-short;
+
+	.o-header-services__drawer-header {
+		display: none;
+		position: relative;
+		overflow: hidden;
+		border-bottom: 1px solid _oHeaderServicesGet('nav-border');
+		padding: 0.5rem 0;
+	}
+
+	.o-header-services__drawer-close-button {
+		position: relative;
+		appearance: none;
+		font-family: inherit;
+		font-size: inherit;
+		background: transparent;
+		border: 0;
+		vertical-align: middle;
+		float: right;
+		&:after {
+			content: '';
+			@include oIconsGetIcon('cross', _oHeaderServicesGet('arrow-icon-color'),  1.5rem);
+			vertical-align: inherit;
+		}
+
+		&:hover {
+			color: _oHeaderServicesGet('text-hover-color');
+
+			&:after {
+				@if _oHeaderServicesGet('text-hover-color') {
+					@include oIconsGetIcon('cross', _oHeaderServicesGet('text-hover-color'), 1.5rem);
+					vertical-align: inherit;
+				}
+			}
+		}
+	}
+
+	.o-header-services .o-header-services__primary-nav--drawer {
+		li[data-o-header-services-level] {
+			display: flex;
+			flex-wrap: wrap;
+			width: 100%;
+
+			> a {
+				flex-grow: 1;
+			}
+
+			.o-header-services__drop-down-button {
+				height: oTypographySpacingSize(10);
+				border: 1px solid _oHeaderServicesGet('nav-border');
+				border-top: 0px;
+			}
+		}
+
+		ul[data-o-header-services-level] {
+			border-right: 0;
+			opacity: 0;
+			transition:
+				opacity 0s ease,
+				transform 0s ease;
+		}
+
+		li[aria-expanded=true] {
+			.o-header-services__drop-down-button {
+				border-width: 0 1px;
+			}
+
+			ul[data-o-header-services-level] {
+				opacity: 1;
+				position: relative;
+				width: 100%;
+				z-index: 2;
+			}
+		}
+	}
+
+	.o-header-services .o-header-services__primary-nav.o-header-services__primary-nav--drawer {
+		background-color: rgba(0, 0, 0, 0.8);
+		position: fixed;
+		top: 0;
 		left: 0;
 		right: 0;
 		bottom: 0;
@@ -25,6 +100,22 @@
 				transform 0.5s $o-visual-effects-transition-expand;
 			height: 100%;
 			width: calc(100% - 120px);
+			background-color: _oHeaderServicesGet('drawer-background');
+			[data-o-header-services-level="2"] a:hover {
+				color: _oHeaderServicesGet('drawer-text-hover-color');
+				background: _oHeaderServicesGet('drawer-nav-hover-background');
+			}
+		}
+
+		li[data-o-header-services-level] .o-header-services__drop-down-button {
+			padding: 0 .4375rem;
+			@if  _oHeaderServicesGet('drawer-button-background') {
+				border: 0;
+				background-color: _oHeaderServicesGet('drawer-button-background');
+				&:hover {
+					background-color: _oHeaderServicesGet('drawer-button-background');
+				}
+			}
 		}
 
 		.o-header-services__related-content {
@@ -34,26 +125,22 @@
 			padding: 0;
 
 			li {
-				background-color: _oHeaderServicesGet('nav-background');
+				background-color: if(_oHeaderServicesGet('drawer-background'), _oHeaderServicesGet('drawer-background'), _oHeaderServicesGet('nav-background'));
 
 				a {
 					color: inherit;
 					font-weight: oFontsWeight('regular');
 					text-transform: none;
-
-					@if oBrandGetCurrentBrand() == 'whitelabel' {
-						padding: 10px 20px;
-					}
-
-					&:hover:before {
-						background-color: transparent;
-					}
+					display: block;
+					margin: 0;
+					padding: $_o-header-services-padding  oTypographySpacingSize(5);
 				}
 
 				a:hover {
 					background-color: none;
 				}
 			}
+
 		}
 
 		&.o-header-services__primary-nav--open {
@@ -61,6 +148,10 @@
 
 			.o-header-services__primary-nav-list {
 				transform: translateX(0%);
+			}
+
+			.o-header-services__drawer-header {
+				display: block;
 			}
 		}
 	}

--- a/src/scss/_drawer.scss
+++ b/src/scss/_drawer.scss
@@ -1,82 +1,9 @@
 /// @access private
 /// @outputs styling for the drawer
+// sass-lint:disable no-qualifying-elements
 @mixin _oHeaderServicesDrawer {
-
-	.o-header-services__drawer-header {
-		display: none;
-		position: relative;
-		overflow: hidden;
-		border-bottom: 1px solid _oHeaderServicesGet('nav-border');
-		padding: 0.5rem 0;
-	}
-
-	.o-header-services__drawer-close-button {
-		position: relative;
-		appearance: none;
-		font-family: inherit;
-		font-size: inherit;
-		background: transparent;
-		border: 0;
-		vertical-align: middle;
-		float: right;
-		&:after {
-			content: '';
-			@include oIconsGetIcon('cross', _oHeaderServicesGet('arrow-icon-color'),  1.5rem);
-			vertical-align: inherit;
-		}
-
-		&:hover {
-			color: _oHeaderServicesGet('text-hover-color');
-
-			&:after {
-				@if _oHeaderServicesGet('text-hover-color') {
-					@include oIconsGetIcon('cross', _oHeaderServicesGet('text-hover-color'), 1.5rem);
-					vertical-align: inherit;
-				}
-			}
-		}
-	}
-
-	.o-header-services .o-header-services__primary-nav--drawer {
-		li[data-o-header-services-level] {
-			display: flex;
-			flex-wrap: wrap;
-			width: 100%;
-
-			> a {
-				flex-grow: 1;
-			}
-
-			.o-header-services__drop-down-button {
-				height: oTypographySpacingSize(10);
-				border: 1px solid _oHeaderServicesGet('nav-border');
-				border-top: 0px;
-			}
-		}
-
-		ul[data-o-header-services-level] {
-			border-right: 0;
-			opacity: 0;
-			transition:
-				opacity 0s ease,
-				transform 0s ease;
-		}
-
-		li[aria-expanded=true] {
-			.o-header-services__drop-down-button {
-				border-width: 0 1px;
-			}
-
-			ul[data-o-header-services-level] {
-				opacity: 1;
-				position: relative;
-				width: 100%;
-				z-index: 2;
-			}
-		}
-	}
-
-	.o-header-services .o-header-services__primary-nav.o-header-services__primary-nav--drawer {
+	.o-header-services__primary-nav.o-header-services__primary-nav--drawer {
+		// Drawer background.
 		background-color: rgba(0, 0, 0, 0.8);
 		position: fixed;
 		top: 0;
@@ -88,6 +15,7 @@
 			visibility 0.01s linear,
 			opacity 0.5s $o-visual-effects-transition-fade;
 
+		// Drawer nav.
 		.o-header-services__primary-nav-list {
 			@include oVisualEffectsShadowsElevation('mid');
 			flex-direction: column;
@@ -95,20 +23,38 @@
 			margin: 0;
 			overflow-y: auto;
 			padding: 0;
+			height: 100%;
+			width: 75vw;
+			background-color: _oHeaderServicesGet('drawer-background');
 			transform: translateX(-100%);
 			transition:
 				transform 0.5s $o-visual-effects-transition-expand;
-			height: 100%;
-			width: calc(100% - 120px);
-			background-color: _oHeaderServicesGet('drawer-background');
-			[data-o-header-services-level="2"] a:hover {
-				color: _oHeaderServicesGet('drawer-text-hover-color');
-				background: _oHeaderServicesGet('drawer-nav-hover-background');
+		}
+
+		// First level nav item.
+		.o-header-services__primary-nav-list > li {
+			display: flex;
+			flex-wrap: wrap;
+			width: 100%;
+
+			// Expand the link to fill the draw,
+			// up to a drop down button if there is one.
+			> a {
+				flex-grow: 1;
 			}
 		}
 
-		li[data-o-header-services-level] .o-header-services__drop-down-button {
-			padding: 0 .4375rem;
+		// Draw's dropdown button.
+		.o-header-services__drop-down-button {
+			padding: 0 0.4375rem;
+			height: oTypographySpacingSize(10);
+			border: 1px solid _oHeaderServicesGet('nav-border');
+			border-top: 0px;
+		}
+
+		// Override the background colour of the draw's dropdown button.
+		.o-header-services__drop-down-button,
+		a[aria-current="true"] + .o-header-services__drop-down-button {
 			@if  _oHeaderServicesGet('drawer-button-background') {
 				border: 0;
 				background-color: _oHeaderServicesGet('drawer-button-background');
@@ -118,15 +64,37 @@
 			}
 		}
 
+		// Second level nav item.
+		[data-o-header-services-level="2"] {
+			border-right: 0;
+			opacity: 0;
+			width: 100%;
+			// Reset the dropdown styles now they are in a drawer.
+			transition: none;
+			z-index: 0;
+			max-width: none;
+			white-space: normal;
+			a:hover {
+				color: _oHeaderServicesGet('drawer-text-hover-color');
+				background: _oHeaderServicesGet('drawer-nav-hover-background');
+			}
+		}
+
+		// Expanded first level nav item.
+		li[data-o-header-services-level][aria-expanded=true] {
+			[data-o-header-services-level="2"] {
+				position: relative;
+				opacity: 1;
+			}
+		}
+
+		// Override related content styles to match the draw.
 		.o-header-services__related-content {
 			display: block;
-			clear: both;
 			margin: oTypographySpacingSize(5) 0 0;
 			padding: 0;
-
 			li {
-				background-color: if(_oHeaderServicesGet('drawer-background'), _oHeaderServicesGet('drawer-background'), _oHeaderServicesGet('nav-background'));
-
+				background-color: inherit;
 				a {
 					color: inherit;
 					font-weight: oFontsWeight('regular');
@@ -135,24 +103,59 @@
 					margin: 0;
 					padding: $_o-header-services-padding  oTypographySpacingSize(5);
 				}
-
 				a:hover {
 					background-color: none;
 				}
 			}
 
 		}
+	}
 
-		&.o-header-services__primary-nav--open {
-			visibility: visible;
+	// The drawer header, which contains the close button.
+	.o-header-services__drawer-header {
+		display: none;
+		position: relative;
+		overflow: hidden;
+		border-bottom: 1px solid _oHeaderServicesGet('nav-border');
+		padding: 0.5rem 0;
+		justify-content: end;
+	}
 
-			.o-header-services__primary-nav-list {
-				transform: translateX(0%);
-			}
+	// The drawer close button.
+	.o-header-services__drawer-close-button {
+		position: relative;
+		appearance: none;
+		font-family: inherit;
+		font-size: inherit;
+		background: transparent;
+		border: 0;
+		vertical-align: middle;
+		&:after {
+			@include oIconsGetIcon('cross', _oHeaderServicesGet('arrow-icon-color'),  1.5rem);
+			content: '';
+			vertical-align: inherit;
+		}
 
-			.o-header-services__drawer-header {
-				display: block;
+		&:hover {
+			color: _oHeaderServicesGet('text-hover-color');
+			&:after {
+				@if _oHeaderServicesGet('text-hover-color') {
+					@include oIconsGetIcon('cross', _oHeaderServicesGet('text-hover-color'), 1.5rem);
+					vertical-align: inherit;
+				}
 			}
 		}
 	}
+
+	// Draw open modifer (closed by default).
+	.o-header-services__primary-nav--drawer.o-header-services__primary-nav--open {
+		visibility: visible;
+		.o-header-services__drawer-header {
+			display: block;
+		}
+		.o-header-services__primary-nav-list {
+			transform: translateX(0%);
+		}
+	}
 }
+// sass-lint:enable no-qualifying-elements

--- a/src/scss/_drawer.scss
+++ b/src/scss/_drawer.scss
@@ -38,11 +38,14 @@
 			flex-wrap: wrap;
 			width: 100%;
 
-			// Expand the link to fill the draw,
-			// up to a drop down button if there is one.
 			@if $drop-down {
 				> a {
-					flex-grow: 1;
+					flex-grow: 1; // Expand the link to fill the draw, up to a drop down button if there is one.
+					// If the nav item padding has been customised, reset within the drawer.
+					@if _oHeaderServicesGet('primary-nav-item-horizontal-padding') {
+						padding-left: oTypographySpacingSize(5);
+						padding-right: oTypographySpacingSize(5);
+					}
 				}
 			}
 		}
@@ -78,6 +81,10 @@
 				z-index: 0;
 				max-width: none;
 				white-space: normal;
+				a {
+					// Indent dropdown links within the drawer.
+					padding-left: oTypographySpacingSize(8);
+				}
 				a:hover {
 					color: _oHeaderServicesGet('drawer-text-hover-color');
 					background: _oHeaderServicesGet('drawer-nav-hover-background');

--- a/src/scss/_drawer.scss
+++ b/src/scss/_drawer.scss
@@ -1,7 +1,8 @@
 /// @access private
 /// @outputs styling for the drawer
+/// @param {Boolean} $drop-down - Whether to include styles to support the dropdown nav.
 // sass-lint:disable no-qualifying-elements
-@mixin _oHeaderServicesDrawer {
+@mixin _oHeaderServicesDrawer($drop-down: true) {
 	.o-header-services__primary-nav.o-header-services__primary-nav--drawer {
 		// Drawer background.
 		background-color: rgba(0, 0, 0, 0.8);
@@ -39,75 +40,79 @@
 
 			// Expand the link to fill the draw,
 			// up to a drop down button if there is one.
-			> a {
-				flex-grow: 1;
+			@if $drop-down {
+				> a {
+					flex-grow: 1;
+				}
 			}
 		}
 
 		// Draw's dropdown button.
-		.o-header-services__drop-down-button {
-			padding: 0 0.4375rem;
-			height: oTypographySpacingSize(10);
-			border: 1px solid _oHeaderServicesGet('nav-border');
-			border-top: 0px;
-		}
+		@if $drop-down {
+			.o-header-services__drop-down-button {
+				padding: 0 0.4375rem;
+				height: oTypographySpacingSize(10);
+				border: 1px solid _oHeaderServicesGet('nav-border');
+				border-top: 0px;
+			}
 
-		// Override the background colour of the draw's dropdown button.
-		.o-header-services__drop-down-button,
-		a[aria-current="true"] + .o-header-services__drop-down-button {
-			@if  _oHeaderServicesGet('drawer-button-background') {
-				border: 0;
-				background-color: _oHeaderServicesGet('drawer-button-background');
-				&:hover {
+			// Override the background colour of the draw's dropdown button.
+			.o-header-services__drop-down-button,
+			a[aria-current="true"] + .o-header-services__drop-down-button {
+				@if  _oHeaderServicesGet('drawer-button-background') {
+					border: 0;
 					background-color: _oHeaderServicesGet('drawer-button-background');
+					&:hover {
+						background-color: _oHeaderServicesGet('drawer-button-background');
+					}
 				}
 			}
-		}
 
-		// Second level nav item.
-		[data-o-header-services-level="2"] {
-			border-right: 0;
-			opacity: 0;
-			width: 100%;
-			// Reset the dropdown styles now they are in a drawer.
-			transition: none;
-			z-index: 0;
-			max-width: none;
-			white-space: normal;
-			a:hover {
-				color: _oHeaderServicesGet('drawer-text-hover-color');
-				background: _oHeaderServicesGet('drawer-nav-hover-background');
-			}
-		}
-
-		// Expanded first level nav item.
-		li[data-o-header-services-level][aria-expanded=true] {
+			// Second level nav item.
 			[data-o-header-services-level="2"] {
-				position: relative;
-				opacity: 1;
-			}
-		}
-
-		// Override related content styles to match the draw.
-		.o-header-services__related-content {
-			display: block;
-			margin: oTypographySpacingSize(5) 0 0;
-			padding: 0;
-			li {
-				background-color: inherit;
-				a {
-					color: inherit;
-					font-weight: oFontsWeight('regular');
-					text-transform: none;
-					display: block;
-					margin: 0;
-					padding: $_o-header-services-padding  oTypographySpacingSize(5);
-				}
+				border-right: 0;
+				opacity: 0;
+				width: 100%;
+				// Reset the dropdown styles now they are in a drawer.
+				transition: none;
+				z-index: 0;
+				max-width: none;
+				white-space: normal;
 				a:hover {
-					background-color: none;
+					color: _oHeaderServicesGet('drawer-text-hover-color');
+					background: _oHeaderServicesGet('drawer-nav-hover-background');
 				}
 			}
 
+			// Expanded first level nav item.
+			li[data-o-header-services-level][aria-expanded=true] {
+				[data-o-header-services-level="2"] {
+					position: relative;
+					opacity: 1;
+				}
+			}
+
+			// Override related content styles to match the draw.
+			.o-header-services__related-content {
+				display: block;
+				margin: oTypographySpacingSize(5) 0 0;
+				padding: 0;
+				li {
+					background-color: inherit;
+					a {
+						color: inherit;
+						font-weight: oFontsWeight('regular');
+						text-transform: none;
+						display: block;
+						margin: 0;
+						padding: $_o-header-services-padding  oTypographySpacingSize(5);
+					}
+					a:hover {
+						background-color: none;
+					}
+				}
+
+			}
 		}
 	}
 

--- a/src/scss/_drop-down.scss
+++ b/src/scss/_drop-down.scss
@@ -14,16 +14,15 @@
 			.o-header-services__drop-down-button {
 				background-color: transparent;
 				border: 0;
-				border-left: 1px solid _oHeaderServicesGet('nav-border');
-				border-right: 1px solid _oHeaderServicesGet('nav-border');
+				border-left: 1px dotted _oHeaderServicesGet('nav-border');
 				height: 100%;
 				vertical-align: top;
+				padding: 0 0.25rem;
 
 				&:after {
-					@include oIconsGetIcon('arrow-down', _oHeaderServicesGet('arrow-icon-color'), 24);
+					@include oIconsGetIcon('arrow-down', _oHeaderServicesGet('arrow-icon-color'), 1.5rem);
 					content: '';
 					transition: transform 0.2s ease;
-					vertical-align: middle;
 				}
 
 				&:hover {
@@ -31,7 +30,7 @@
 
 					&:after {
 						@if _oHeaderServicesGet('arrow-icon-hover-color') {
-							@include oIconsGetIcon('arrow-down', _oHeaderServicesGet('arrow-icon-hover-color'), 24);
+							@include oIconsGetIcon('arrow-down', _oHeaderServicesGet('arrow-icon-hover-color'), 1.5rem);
 						}
 					}
 				}
@@ -56,14 +55,19 @@
 			padding-left: 0;
 			position: absolute;
 			opacity: 0;
-			transform: translateY(-100%);
-			transition:
-				opacity 0.1s linear,
-				transform 0.2s ease-in;
+			transform: translateY(-10%);
+			transition: opacity 0.1s linear, transform 0.1s ease-in;
 			z-index: -1;
+			left: -1px;
+			height: 0;
+			@supports (pointer-events: none) {
+				height: auto;
+				pointer-events: none;
+			}
 
 			&.o-header-services__list--right {
-				right: 0;
+				right: -1px;
+				left: auto;
 			}
 		}
 
@@ -74,56 +78,12 @@
 			}
 
 			ul[data-o-header-services-level] {
+				height: auto;
+				@supports (pointer-events: none) {
+					pointer-events: all;
+				}
 				transform: translateY(0);
 				opacity: 1;
-			}
-		}
-
-		.o-header-services__primary-nav--drawer {
-			li[data-o-header-services-level] {
-				display: flex;
-				flex-wrap: wrap;
-				width: 100%;
-
-				> a {
-					flex-grow: 1;
-				}
-
-				.o-header-services__drop-down-button {
-					height: oTypographySpacingSize(10);
-					border: 1px solid _oHeaderServicesGet('nav-border');
-				}
-
-				@if oBrandGetCurrentBrand() == 'whitelabel' {
-					> a {
-						flex-grow: 0;
-					}
-
-					.o-header-services__drop-down-button {
-						margin-left: auto;
-					}
-				};
-			}
-
-			ul[data-o-header-services-level] {
-				border-right: 0;
-				opacity: 0;
-				transition:
-					opacity 0s ease,
-					transform 0s ease;
-			}
-
-			li[aria-expanded=true] {
-				.o-header-services__drop-down-button {
-					border-width: 0 1px;
-				}
-
-				ul[data-o-header-services-level] {
-					opacity: 1;
-					position: relative;
-					width: 100%;
-					z-index: 2;
-				}
 			}
 		}
 	}

--- a/src/scss/_drop-down.scss
+++ b/src/scss/_drop-down.scss
@@ -2,103 +2,87 @@
 /// @access private
 /// @outputs styling for primary navigation drop down menus
 @mixin _oHeaderServicesDropDown() {
-	.o-header-services {
-		li[data-o-header-services-level] {
-			position: relative;
-			min-height: oTypographySpacingSize(10);
+	// So the dropdown stays above other elements.
+	.o-header-services__primary-nav {
+		z-index: 1;
+	}
 
-			> a {
-				display: inline-block;
-			}
+	// Drop down button.
+	.o-header-services__drop-down-button {
+		background-color: transparent;
+		border: 0;
+		border-left: 1px dotted _oHeaderServicesGet('nav-border');
+		height: 100%;
+		vertical-align: top;
+		padding: 0 0.25rem;
 
-			.o-header-services__drop-down-button {
-				background-color: transparent;
-				border: 0;
-				border-left: 1px dotted _oHeaderServicesGet('nav-border');
-				height: 100%;
-				vertical-align: top;
-				padding: 0 0.25rem;
-
-				&:after {
-					@include oIconsGetIcon('arrow-down', _oHeaderServicesGet('arrow-icon-color'), 1.5rem);
-					content: '';
-					transition: transform 0.2s ease;
-				}
-
-				&:hover {
-					background-color: _oHeaderServicesGet('button-hover-color');
-
-					&:after {
-						@if _oHeaderServicesGet('arrow-icon-hover-color') {
-							@include oIconsGetIcon('arrow-down', _oHeaderServicesGet('arrow-icon-hover-color'), 1.5rem);
-						}
-					}
-				}
-			}
-
-			a[aria-current='true'] + .o-header-services__drop-down-button {
-				background-color: _oHeaderServicesGet('nav-hover-background');
-
-
-				&:hover {
-					background-color: _oHeaderServicesGet('button-hover-color');
-				}
-			}
+		&:after {
+			@include oIconsGetIcon('arrow-down', _oHeaderServicesGet('arrow-icon-color'), 1.5rem);
+			content: '';
+			transition: transform 0.2s ease;
 		}
 
-		ul[data-o-header-services-level] {
-			@include oTypographySize(-1);
-			background: _oHeaderServicesGet('nav-background');
-			border: 1px solid _oHeaderServicesGet('nav-border');
-			box-sizing: border-box;
-			min-width: auto;
-			padding-left: 0;
-			position: absolute;
-			opacity: 0;
-			transform: translateY(-10%);
-			transition: opacity 0.1s linear, transform 0.1s ease-in;
-			z-index: -1;
-			left: -1px;
-			height: 0;
-			@supports (pointer-events: none) {
-				height: auto;
-				pointer-events: none;
-			}
+		&:hover {
+			background-color: _oHeaderServicesGet('button-hover-color');
 
-			&.o-header-services__list--right {
-				right: -1px;
-				left: auto;
-			}
-		}
-
-		.core li[data-o-header-services-level]:hover,
-		li[aria-expanded=true] {
-			.o-header-services__drop-down-button:after {
-				transform: rotate(-180deg);
-			}
-
-			ul[data-o-header-services-level] {
-				height: auto;
-				@supports (pointer-events: none) {
-					pointer-events: all;
+			&:after {
+				@if _oHeaderServicesGet('arrow-icon-hover-color') {
+					@include oIconsGetIcon('arrow-down', _oHeaderServicesGet('arrow-icon-hover-color'), 1.5rem);
 				}
-				transform: translateY(0);
-				opacity: 1;
 			}
 		}
 	}
 
-	.core .o-header-services {
-		li[data-o-header-services-level] .o-header-services__drop-down-button:hover {
+	// Current drop down button.
+	li[data-o-header-services-level] a[aria-current='true'] + .o-header-services__drop-down-button {
+		background-color: _oHeaderServicesGet('nav-hover-background');
+		&:hover {
+			background-color: _oHeaderServicesGet('button-hover-color');
+		}
+	}
 
-			&:after {
-				transform: rotate(-180deg);
-			}
+	// Drop down list.
+	ul[data-o-header-services-level="2"] {
+		@include oTypographySize(-1);
+		background: _oHeaderServicesGet('nav-background');
+		border: 1px solid _oHeaderServicesGet('nav-border');
+		box-sizing: border-box;
+		padding-left: 0;
+		position: absolute;
+		opacity: 0;
+		transform: translateY(-10%);
+		transition: opacity 0.1s linear, transform 0.1s ease-in;
+		left: -1px;
+		z-index: -1; // So the dropdown doesn't cover the link/button whilst animating.
 
-			+ ul[data-o-header-services-level] {
-				transform: translateY(0);
-				opacity: 1;
+		// The dropdown list is inviisble when closed.
+		// This is so it doesn't block interaction with other elements.
+		height: 0;
+		@supports (pointer-events: none) {
+			height: auto;
+			pointer-events: none;
+		}
+
+		&.o-header-services__list--right {
+			right: -1px;
+			left: auto;
+		}
+	}
+
+	// Drop down list (opened state).
+	.core li[data-o-header-services-level]:hover,
+	li[aria-expanded=true] {
+		.o-header-services__drop-down-button:after {
+			transform: rotate(-180deg);
+		}
+
+		ul[data-o-header-services-level] {
+			height: auto;
+			@supports (pointer-events: none) {
+				pointer-events: all;
 			}
+			transform: translateY(0);
+			opacity: 1;
 		}
 	}
 }

--- a/src/scss/_drop-down.scss
+++ b/src/scss/_drop-down.scss
@@ -69,13 +69,16 @@
 		}
 	}
 
+	// Completely hide visually hidden elements untill the dropdown is open.
+	ul[data-o-header-services-level] .o-header-services__visually-hidden {
+		display: none;
+	}
+
 	// Drop down list (opened state).
 	.core li[data-o-header-services-level]:hover,
 	li[aria-expanded=true] {
-		.o-header-services__drop-down-button:after {
-			transform: rotate(-180deg);
-		}
 
+		// Reveal the dropdown.
 		ul[data-o-header-services-level] {
 			height: auto;
 			@supports (pointer-events: none) {
@@ -83,6 +86,16 @@
 			}
 			transform: translateY(0);
 			opacity: 1;
+		}
+
+		// Reveal visually hidden elements within the dropdown to screen readers.
+		ul[data-o-header-services-level] .o-header-services__visually-hidden {
+			display: initial;
+		}
+
+		// Update the dropdown icon to show the drawer is open.
+		.o-header-services__drop-down-button:after {
+			transform: rotate(-180deg);
 		}
 	}
 }

--- a/src/scss/_primary-nav.scss
+++ b/src/scss/_primary-nav.scss
@@ -1,6 +1,7 @@
 /// @access private
 /// @outputs styling for primary nav
-@mixin _oHeaderServicesPrimaryNav() {
+/// @param {Boolean} $drop-down - Whether to include styles to support the dropdown nav.
+@mixin _oHeaderServicesPrimaryNav($drop-down) {
 	.o-header-services__primary-nav {
 		position: relative;
 		background-color: _oHeaderServicesGet('nav-background');
@@ -57,5 +58,5 @@
 		}
 	}
 
-	@include _oHeaderServicesDrawer();
+	@include _oHeaderServicesDrawer($drop-down);
 };

--- a/src/scss/_primary-nav.scss
+++ b/src/scss/_primary-nav.scss
@@ -5,7 +5,6 @@
 		position: relative;
 		background-color: _oHeaderServicesGet('nav-background');
 		border-bottom: 1px solid _oHeaderServicesGet('nav-border');
-		z-index: 1;
 	}
 
 	.o-header-services__primary-nav-list {
@@ -15,19 +14,46 @@
 		flex-wrap: wrap;
 		margin: auto;
 
-		@include oGridRespondTo(S) {
-			padding: 0;
-		};
+		> li {
+			position: relative;
+		}
 
 		> li a {
-			@include _oHeaderServicesHover($underline: false);
 			@include oTypographyBold('sans');
+			position: relative;
+			color: _oHeaderServicesGet('nav-text');
+			display: inline-block;
+			margin: 0;
+			padding: $_o-header-services-padding  oTypographySpacingSize(5);
 			text-transform: uppercase;
-			min-height: oTypographySpacingSize(5);
+			box-sizing: border-box;
+
+			&:hover {
+				color: _oHeaderServicesGet('text-hover-color');
+			}
+
+			&:hover,
+			&[aria-current=true] {
+				background-color: _oHeaderServicesGet('nav-hover-background');
+			}
 		}
 
 		> li:not(:last-child) {
 			border-right: 1px solid _oHeaderServicesGet('nav-border');
+		}
+
+		[data-o-header-services-level="2"] {
+			> li a {
+				display: block;
+			}
+			max-width: 50vw;
+			overflow: hidden;
+			white-space: nowrap;
+			> li a {
+				text-overflow: ellipsis;
+				max-width: 100%;
+				overflow: hidden;
+			}
 		}
 	}
 

--- a/src/scss/_primary-nav.scss
+++ b/src/scss/_primary-nav.scss
@@ -11,11 +11,17 @@
 	}
 
 	.o-header-services__primary-nav-list {
-		@include oGridContainer;
+		@include oGridContainer();
 		background-color: _oHeaderServicesGet('nav-background');
 		display: flex;
 		flex-wrap: wrap;
 		margin: auto;
+
+		// Remove the padding from the grid container.
+		// Unless the nav items have custom padding which is smaller than the grid container's grid gap.
+		@include oGridRespondTo(S) {
+			padding: 0 if(_oHeaderServicesGet('primary-nav-item-horizontal-padding'), calc(map-get($o-grid-gutters, 'M') - #{_oHeaderServicesGet('primary-nav-item-horizontal-padding')}), 0);
+		};
 
 		> li {
 			position: relative;

--- a/src/scss/_primary-nav.scss
+++ b/src/scss/_primary-nav.scss
@@ -19,12 +19,15 @@
 			padding: 0;
 		};
 
-		a {
-			$underline: if(_oHeaderServicesGet('nav-background') == _oHeaderServicesGet('nav-hover-background'), true, false);
-			@include _oHeaderServicesHover($underline);
+		> li a {
+			@include _oHeaderServicesHover($underline: false);
 			@include oTypographyBold('sans');
 			text-transform: uppercase;
 			min-height: oTypographySpacingSize(5);
+		}
+
+		> li:not(:last-child) {
+			border-right: 1px solid _oHeaderServicesGet('nav-border');
 		}
 	}
 

--- a/src/scss/_primary-nav.scss
+++ b/src/scss/_primary-nav.scss
@@ -5,7 +5,9 @@
 	.o-header-services__primary-nav {
 		position: relative;
 		background-color: _oHeaderServicesGet('nav-background');
-		border-bottom: 1px solid _oHeaderServicesGet('nav-border');
+		@if (_oHeaderServicesGet('nav-background') == _oHeaderServicesGet('top-background')) {
+			border-top: 1px solid _oHeaderServicesGet('nav-border');
+		}
 	}
 
 	.o-header-services__primary-nav-list {
@@ -25,7 +27,7 @@
 			color: _oHeaderServicesGet('nav-text');
 			display: inline-block;
 			margin: 0;
-			padding: $_o-header-services-padding  oTypographySpacingSize(5);
+			padding: $_o-header-services-padding if(_oHeaderServicesGet('primary-nav-item-horizontal-padding'), _oHeaderServicesGet('primary-nav-item-horizontal-padding'), oTypographySpacingSize(5));
 			text-transform: uppercase;
 			box-sizing: border-box;
 

--- a/src/scss/_primary-nav.scss
+++ b/src/scss/_primary-nav.scss
@@ -20,7 +20,7 @@
 		// Remove the padding from the grid container.
 		// Unless the nav items have custom padding which is smaller than the grid container's grid gap.
 		@include oGridRespondTo(S) {
-			padding: 0 if(_oHeaderServicesGet('primary-nav-item-horizontal-padding'), calc(map-get($o-grid-gutters, 'M') - #{_oHeaderServicesGet('primary-nav-item-horizontal-padding')}), 0);
+			padding: 0 if(_oHeaderServicesGet('primary-nav-item-horizontal-padding'), calc(#{map-get($o-grid-gutters, 'M')} - #{_oHeaderServicesGet('primary-nav-item-horizontal-padding')}), 0);
 		};
 
 		> li {

--- a/src/scss/_secondary-nav.scss
+++ b/src/scss/_secondary-nav.scss
@@ -1,13 +1,19 @@
 /// @access private
+/// @param {String} $draw-breakpoint At what breakpoint to show the draw hamburger.
 /// @outputs styling for sub nav
-@mixin _oHeaderServicesSecondaryNav() {
+@mixin _oHeaderServicesSecondaryNav($draw-breakpoint) {
 	.o-header-services__secondary-nav {
 		position: relative;
 		background-color: _oHeaderServicesGet('nav-background');
 		border-top: 1px solid _oHeaderServicesGet('nav-border');
-		border-bottom: 1px solid _oHeaderServicesGet('nav-border');
 		overflow: hidden;
 		max-height: #{(36/16)}rem; // To hide the scroll bar.
+		// Remove border between the top and the secondary nav if their background is different.
+		@if (_oHeaderServicesGet('nav-background') != _oHeaderServicesGet('top-background')) {
+			@include oGridRespondTo($until: $draw-breakpoint) {
+				border-top: 0;
+			}
+		}
 	}
 
 	.o-header-services__secondary-nav-content {

--- a/src/scss/_secondary-nav.scss
+++ b/src/scss/_secondary-nav.scss
@@ -7,6 +7,7 @@
 		border-top: 1px solid _oHeaderServicesGet('nav-border');
 		border-bottom: 1px solid _oHeaderServicesGet('nav-border');
 		overflow: hidden;
+		max-height: #{(36/16)}rem; // To hide the scroll bar.
 	}
 
 	.o-header-services__secondary-nav-content {
@@ -15,7 +16,7 @@
 		white-space: nowrap;
 		overflow-x: auto;
 		padding: 0 oTypographySpacingSize(5);
-		max-height: $_o-header-services-sub-nav-height;
+		padding-bottom: 1rem; // To hide the scroll bar.
 	}
 
 	.o-header-services__secondary-nav-list {
@@ -83,7 +84,10 @@
 
 		&:first-child {
 			margin-left:  oTypographySpacingSize(3);
-			padding-left:  oTypographySpacingSize(3);
+		}
+
+		&:last-child {
+			padding-right:  oTypographySpacingSize(3);
 		}
 
 		&:first-child:before {

--- a/src/scss/_secondary-nav.scss
+++ b/src/scss/_secondary-nav.scss
@@ -13,7 +13,7 @@
 		display: flex;
 		white-space: nowrap;
 		overflow-x: auto;
-		padding: 0 20px;
+		padding: 0 oTypographySpacingSize(5);
 		max-height: $_o-header-services-sub-nav-height;
 	}
 
@@ -27,9 +27,27 @@
 			position: relative;
 
 			a {
-				@include _oHeaderServicesHover($underline: true);
+				color: _oHeaderServicesGet('nav-text');
+				position: relative;
+				display: inline-block;
 				padding: oTypographySpacingSize(2) 0;
 				margin: 0;
+
+				&:hover,
+				&[aria-current=true] {
+					color: _oHeaderServicesGet('text-hover-color');
+				}
+
+				&:hover:before,
+				&[aria-current=true]:before {
+					content: '';
+					position: absolute;
+					bottom: 0;
+					left: 0;
+					width: 100%;
+					height: oTypographySpacingSize(1);
+					background-color: _oHeaderServicesGet('nav-underline-color');
+				}
 			}
 		}
 	}

--- a/src/scss/_secondary-nav.scss
+++ b/src/scss/_secondary-nav.scss
@@ -4,6 +4,7 @@
 	.o-header-services__secondary-nav {
 		position: relative;
 		background-color: _oHeaderServicesGet('nav-background');
+		border-top: 1px solid _oHeaderServicesGet('nav-border');
 		border-bottom: 1px solid _oHeaderServicesGet('nav-border');
 		overflow: hidden;
 	}

--- a/src/scss/_theme.scss
+++ b/src/scss/_theme.scss
@@ -32,9 +32,21 @@
 				}
 			}
 
+			// The drawer close button.
+			.o-header-services__drawer-close-button,
+			.o-header-services__drawer-close-button:hover {
+				color: _oHeaderServicesGet('nav-text', $from: $theme);
+				&:after {
+					@include oIconsGetIcon('cross', _oHeaderServicesGet('nav-text', $from: $theme),  1.5rem);
+					vertical-align: inherit;
+				}
+			}
+
 			.o-header-services__primary-nav-list {
 				background-color: _oHeaderServicesGet('nav-background', $from: $theme);
-
+				> li:not(:last-child) {
+					border: 0;
+				}
 				a {
 					color: _oHeaderServicesGet('nav-text', $from: $theme);
 

--- a/src/scss/_top.scss
+++ b/src/scss/_top.scss
@@ -2,14 +2,13 @@
 /// @param {String} $logo [ft-logo depending on brand (pink or white)]
 /// @param {String} $draw-breakpoint At what breakpoint to show the draw hamburger.
 /// @outputs styling for title section of header
-@mixin _oHeaderServicesTop($logo, $draw-breakpoint: M) {
+@mixin _oHeaderServicesTop($logo, $draw-breakpoint) {
 	.o-header-services__top {
 		@include oGridContainer;
 		background-color: _oHeaderServicesGet('top-background');
 		color: _oHeaderServicesGet('top-text');
 		display: flex;
 		overflow: hidden;
-		padding: 0;
 
 		a {
 			color: inherit;
@@ -69,12 +68,12 @@
 	}
 
 	.o-header-services__product-name {
-		@include oTypographySize($scale: 4);
+		@include oTypographySize($scale: 2);
 		@include oTypographyBold('sans');
 		text-overflow: ellipsis;
 
-		@include oGridRespondTo($until: $draw-breakpoint) {
-			@include oTypographySize($scale: 2);
+		@include oGridRespondTo(M) {
+			@include oTypographySize($scale: 4);
 		}
 	}
 
@@ -83,9 +82,9 @@
 		margin-left: $_o-header-services-padding;
 		text-overflow: ellipsis;
 		overflow: hidden;
-
-		@include oGridRespondTo($until: L) {
-			display: none;
+		display: none;
+		@include oGridRespondTo(L) {
+			display: inline-block;
 		}
 	}
 

--- a/src/scss/_top.scss
+++ b/src/scss/_top.scss
@@ -8,7 +8,6 @@
 		color: _oHeaderServicesGet('top-text');
 		display: flex;
 		overflow: hidden;
-		z-index: $_o-header-services-top-bar-z-index;
 		padding: 0;
 
 		a {
@@ -60,10 +59,6 @@
 		height: $_o-header-services-top-bar-short;
 		width: $_o-header-services-top-bar-short;
 		transition: transform 0.2s ease;
-
-		&.o-header-services__hambuger--open {
-			transform: rotate(90deg);
-		}
 	}
 
 	.o-header-services__product-name {

--- a/src/scss/_top.scss
+++ b/src/scss/_top.scss
@@ -1,7 +1,8 @@
 /// @access private
 /// @param {String} $logo [ft-logo depending on brand (pink or white)]
+/// @param {String} $draw-breakpoint At what breakpoint to show the draw hamburger.
 /// @outputs styling for title section of header
-@mixin _oHeaderServicesTop($logo) {
+@mixin _oHeaderServicesTop($logo, $draw-breakpoint: M) {
 	.o-header-services__top {
 		@include oGridContainer;
 		background-color: _oHeaderServicesGet('top-background');
@@ -26,14 +27,20 @@
 			background-repeat: no-repeat;
 			background-size: contain;
 			background-position: 0;
-			margin: 0;
 			height: $_o-header-services-top-bar-short;
 			width: $_o-header-services-top-bar-short;
 
 			@include oGridRespondTo(M) {
-				margin: oTypographySpacingSize(2) oTypographySpacingSize(2) oTypographySpacingSize(2) 0;
 				height: $_o-header-services-top-icon-size;
 				width: $_o-header-services-top-icon-size;
+			}
+
+			@include oGridRespondTo($draw-breakpoint) {
+				margin: oTypographySpacingSize(2);
+			}
+
+			@include oGridRespondTo(M) {
+				margin-left: 0;
 			}
 		}
 
@@ -45,7 +52,7 @@
 	.o-header-services__hamburger {
 		height: $_o-header-services-top-bar-short;
 		width: $_o-header-services-top-bar-short;
-		@include oGridRespondTo(M) {
+		@include oGridRespondTo($draw-breakpoint) {
 			display: none;
 		}
 	}
@@ -66,7 +73,7 @@
 		@include oTypographyBold('sans');
 		text-overflow: ellipsis;
 
-		@include oGridRespondTo($until: M) {
+		@include oGridRespondTo($until: $draw-breakpoint) {
 			@include oTypographySize($scale: 2);
 		}
 	}
@@ -101,7 +108,8 @@
 				margin: 0;
 				color: _oHeaderServicesGet('top-text');
 
-				@include oGridRespondTo($from: M) {
+
+				@include oGridRespondTo($from: $draw-breakpoint) {
 					display: block;
 					padding: $_o-header-services-padding oTypographySpacingSize(3);
 					margin: 0;

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -5,7 +5,6 @@ $_o-header-services-padding: oGridGutter();
 $_o-header-services-top-bar-short: oTypographySpacingSize(11);
 
 $_o-header-services-primary-nav-z-index: 1;
-$_o-header-services-sub-nav-height: oTypographySpacingSize(9);
 
  $_o-header-services-top-icon-size: oTypographySpacingSize(10);
  $_o-header-services-button-icon-size: oTypographySpacingSize(6);

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -3,7 +3,6 @@ $o-header-services-is-silent: true !default;
 $_o-header-services-padding: oGridGutter();
 
 $_o-header-services-top-bar-short: oTypographySpacingSize(11);
-$_o-header-services-top-bar-z-index: 2;
 
 $_o-header-services-primary-nav-z-index: 1;
 $_o-header-services-sub-nav-height: oTypographySpacingSize(9);

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -1,86 +1,91 @@
-const	withPrimaryNav = `
-	<header class='o-header-services' data-o-component='o-header-services'>
-		<div class='o-header-services__top'>
+const withPrimaryNav = `
+<header class="o-header-services " data-o-component="o-header-services">
+	<div class="o-header-services__top">
 			<div class="o-header-services__hamburger">
-				<a class="o-header-services__hamburger-icon" href="#" role="button"><span class="o-header__visually-hidden">Menu</span></a>
+				<a class="o-header-services__hamburger-icon" href="#" role="button">
+					<span class="o-header-services__visually-hidden">Open primary navigation</span>
+				</a>
 			</div>
-			<div class='o-header-services__logo'></div>
-			<div class='o-header-services__title'>
-				<a class='o-header-services__product-name' href="/">Tool or Service name</a>
-				<span class='o-header-services__product-tagline'>Tagline to explain the product here</span>
-			</div>
-			<ul class="o-header-services__related-content">
-				<li>
-					<a href="#">XXXX</a>
-				</li>
-				<li>
-					<a href="#">Sign in</a>
-				</li>
-			</ul>
+		<div class="o-header-services__logo"></div>
+		<div class="o-header-services__title">
+			<a class="o-header-services__product-name" href="/">Tool or Service name</a>
+			<span class="o-header-services__product-tagline">Tagline to explain the product here</span>
 		</div>
-		<nav class='o-header-services__primary-nav'>
-			<ul class="o-header-services__primary-nav-list">
-				<li data-o-header-services-level="1">
-					<a href="#">Fruit</a>
-					<button type="button" name="button" aria-label="Toggle dropdown menu"></button>
-					<ul data-o-header-services-level="2" aria-hidden="true">
-						<li>
-							<a href="#">Fruit</a>
-						</li>
-						<li>
-							<a href="#">Apples & Pears</a>
-						</li>
-						<li>
-							<a href="#">Citrus</a>
-						</li>
-						<li>
-							<a href="#">Stone fruit</a>
-						</li>
-						<li>
-							<a href="#">Tropical / Exotic</a>
-						</li>
-						<li>
-							<a href="#">Berries</a>
-						</li>
-						<li>
-							<a href="#">Melons</a>
-						</li>
-						<li>
-							<a href="#">Tomatoes & Avocados</a>
-						</li>
-					</ul>
-				</li>
-				<li data-o-header-services-level="1">
-					<a aria-current="true" href="#">Vegetables</a>
-					<button type="button" name="button" aria-label="Toggle dropdown menu"></button>
-					<ul data-o-header-services-level="2" aria-hidden='true' >
-						<li>
-							<a href="#">Vegetables</a>
-						</li>
-						<li>
-							<a href="#">Leafy green</a>
-						</li>
-						<li>
-							<a href="#">Cruciferous</a>
-						</li>
-						<li>
-							<a href="#">Marrow</a>
-						</li>
-						<li>
-							<a href="#">Root</a>
-						</li>
-						<li>
-							<a href="#">Edible plant stem</a>
-						</li>
-						<li>
-							<a href="#">Allium</a>
-						</li>
-					</ul>
-				</li>
-			</ul>
-		</nav>
-	</header>
-`;
+		<ul class="o-header-services__related-content">
+			<li>
+				<a href="">XXXX</a>
+			</li>
+			<li>
+				<a href="">Sign in</a>
+			</li>
+		</ul>
+	</div>
+
+	<nav class="o-header-services__primary-nav" aria-label="primary">
+		<ul class="o-header-services__primary-nav-list">
+			<li data-o-header-services-level="1">
+				<a aria-current="true" href="">Fruit</a><!--
+				--><button class="o-header-services__drop-down-button" type="button" name="button" aria-label="Toggle dropdown menu"></button>
+				<ul data-o-header-services-level="2" aria-hidden="true">
+                    <li>
+                        <a href="#">Fruit</a>
+                    </li>
+                    <li>
+                        <a href="#">Apples & Pears</a>
+                    </li>
+                    <li>
+                        <a href="#">Citrus</a>
+                    </li>
+                    <li>
+                        <a href="#">Stone fruit</a>
+                    </li>
+                    <li>
+                        <a href="#">Tropical / Exotic</a>
+                    </li>
+                    <li>
+                        <a href="#">Berries</a>
+                    </li>
+                    <li>
+                        <a href="#">Melons</a>
+                    </li>
+                    <li>
+                        <a href="#">Tomatoes & Avocados</a>
+                    </li>
+					<button class="o-header-services__visually-hidden" type="button" name="button">Close dropdown menu</button>
+				</ul>
+			</li>
+			<li data-o-header-services-level="1">
+				<a href="">Vegetables</a><!--
+				--><button class="o-header-services__drop-down-button" type="button" name="button" aria-label="Toggle dropdown menu"></button>
+				<ul data-o-header-services-level="2" aria-hidden="true">
+                    <li>
+                        <a href="#">Vegetables</a>
+                    </li>
+                    <li>
+                        <a href="#">Leafy green</a>
+                    </li>
+                    <li>
+                        <a href="#">Cruciferous</a>
+                    </li>
+                    <li>
+                        <a href="#">Marrow</a>
+                    </li>
+                    <li>
+                        <a href="#">Root</a>
+                    </li>
+                    <li>
+                        <a href="#">Edible plant stem</a>
+                    </li>
+                    <li>
+                        <a href="#">Allium</a>
+                    </li>
+					<button class="o-header-services__visually-hidden" type="button" name="button">Close dropdown menu</button>
+				</ul>
+			</li>
+		</ul>
+	</nav>
+
+</header>`;
 
 export {
 	withPrimaryNav

--- a/test/js/drawer.test.js
+++ b/test/js/drawer.test.js
@@ -7,16 +7,19 @@ import * as fixtures from '../helpers/fixtures';
 describe('Drawer', () => {
 	let headerEl;
 	let primaryNav;
+	let sandbox;
 
 	beforeEach(() => {
-		document.body.innerHTML = fixtures.withPrimaryNav;
+		sandbox = document.createElement('div');
+		sandbox.innerHTML = fixtures.withPrimaryNav;
+		document.body.appendChild(sandbox);
 		headerEl = document.body.querySelector('.o-header-services');
 		new HeaderServices(headerEl);
 		primaryNav = headerEl.querySelector('.o-header-services__primary-nav');
 	});
 
 	afterEach(() => {
-		document.body.innerHTML = '';
+		document.body.removeChild(sandbox);
 		window.resizeTo(window.screen.availHeight, window.screen.availWidth);
 	});
 
@@ -54,8 +57,8 @@ describe('Drawer', () => {
 			}, 100);
 		});
 
-		it('hides primary nav on second burger icon click', (done) => {
-			let burgerIcon = '.o-header-services__hamburger-icon';
+		it('hides primary nav on close button click', (done) => {
+			let burgerIcon = '.o-header-services__drawer-close-button';
 
 			setTimeout(() => {
 				click(burgerIcon);

--- a/test/js/drawer.test.js
+++ b/test/js/drawer.test.js
@@ -21,8 +21,11 @@ describe('Drawer', () => {
 	});
 
 	context('on viewports above 740px', () => {
-		it('primary nav is visibile', () => {
-			proclaim.isTrue(primaryNav.classList.contains('o-header-services__primary-nav--open'));
+		it('primary nav is visibile', (done) => {
+			setTimeout(() => {
+				proclaim.isTrue(primaryNav.classList.contains('o-header-services__primary-nav--open'));
+				done();
+			}, 100);
 		});
 	});
 
@@ -34,35 +37,39 @@ describe('Drawer', () => {
 			click = element => headerEl.querySelector(element).dispatchEvent(new Event('click'));
 		});
 
-		it('primary nav is hidden', () => {
+		it('primary nav is hidden', (done) => {
 			setTimeout(() => {
 				proclaim.isFalse(primaryNav.classList.contains('o-header-services__primary-nav--open'));
 				proclaim.isTrue(primaryNav.hasAttribute('aria-hidden', 'true'));
+				done();
 			}, 100);
 		});
 
-		it('display primary nav on burger icon click', () => {
+		it('display primary nav on burger icon click', (done) => {
 			let burgerIcon = '.o-header-services__hamburger-icon';
 			setTimeout(() => {
 				click(burgerIcon);
 				proclaim.isTrue(primaryNav.classList.contains('o-header-services__primary-nav--open'));
+				done();
 			}, 100);
 		});
 
-		it('hides primary nav on second burger icon click', () => {
+		it('hides primary nav on second burger icon click', (done) => {
 			let burgerIcon = '.o-header-services__hamburger-icon';
 
 			setTimeout(() => {
 				click(burgerIcon);
 				click(burgerIcon);
 				proclaim.isTrue(primaryNav.classList.contains('o-header-services__primary-nav--open'));
+				done();
 			}, 100);
 		});
 
-		it('shifts related content to primary nav', () => {
+		it('shifts related content to primary nav', (done) => {
 			setTimeout(() => {
 				let listItems = primaryNav.querySelector('ul');
 				proclaim.equal(listItems.children.length, 3);
+				done();
 			}, 100);
 		});
 	});

--- a/test/js/drawer.test.js
+++ b/test/js/drawer.test.js
@@ -20,58 +20,12 @@ describe('Drawer', () => {
 
 	afterEach(() => {
 		document.body.removeChild(sandbox);
-		window.resizeTo(window.screen.availHeight, window.screen.availWidth);
 	});
 
 	context('on viewports above 740px', () => {
 		it('primary nav is visibile', (done) => {
 			setTimeout(() => {
 				proclaim.isTrue(primaryNav.classList.contains('o-header-services__primary-nav--open'));
-				done();
-			}, 100);
-		});
-	});
-
-	context('on viewports below 740px', () => {
-		let click;
-
-		beforeEach(() => {
-			window.resizeTo(740, 740);
-			click = element => headerEl.querySelector(element).dispatchEvent(new Event('click'));
-		});
-
-		it('primary nav is hidden', (done) => {
-			setTimeout(() => {
-				proclaim.isFalse(primaryNav.classList.contains('o-header-services__primary-nav--open'));
-				proclaim.isTrue(primaryNav.hasAttribute('aria-hidden', 'true'));
-				done();
-			}, 100);
-		});
-
-		it('display primary nav on burger icon click', (done) => {
-			let burgerIcon = '.o-header-services__hamburger-icon';
-			setTimeout(() => {
-				click(burgerIcon);
-				proclaim.isTrue(primaryNav.classList.contains('o-header-services__primary-nav--open'));
-				done();
-			}, 100);
-		});
-
-		it('hides primary nav on close button click', (done) => {
-			let burgerIcon = '.o-header-services__drawer-close-button';
-
-			setTimeout(() => {
-				click(burgerIcon);
-				click(burgerIcon);
-				proclaim.isTrue(primaryNav.classList.contains('o-header-services__primary-nav--open'));
-				done();
-			}, 100);
-		});
-
-		it('shifts related content to primary nav', (done) => {
-			setTimeout(() => {
-				let listItems = primaryNav.querySelector('ul');
-				proclaim.equal(listItems.children.length, 3);
 				done();
 			}, 100);
 		});

--- a/test/js/drop-down.test.js
+++ b/test/js/drop-down.test.js
@@ -9,9 +9,12 @@ describe('Dropdown', () => {
 	let click;
 	let headerEl;
 	let navItems;
+	let sandbox;
 
 	beforeEach(() => {
-		document.body.innerHTML = fixtures.withPrimaryNav;
+		sandbox = document.createElement('div');
+		sandbox.innerHTML = fixtures.withPrimaryNav;
+		document.body.appendChild(sandbox);
 		headerEl = document.body.querySelector('.o-header-services');
 		new HeaderServices(headerEl);
 		navItems = document.querySelectorAll('li[data-o-header-services-level="1"]');
@@ -19,7 +22,7 @@ describe('Dropdown', () => {
 	});
 
 	afterEach(() => {
-		document.body.removeChild(headerEl);
+		document.body.removeChild(sandbox);
 		headerEl = null;
 	});
 
@@ -60,7 +63,7 @@ describe('Dropdown', () => {
 
 	describe('toggles drop down menu via `aria-expanded`', () => {
 		it('repositions dropdown menu if it doesnt fit to the right of the window', () => {
-			navItems[1].style.width = '1000px';
+			navItems[1].querySelector('li').style.width = window.innerWidth + 1;
 			click(navItems[1], 'button');
 			proclaim.isTrue(navItems[1].lastElementChild.classList.contains('o-header-services__list--right'));
 		});

--- a/test/js/drop-down.test.js
+++ b/test/js/drop-down.test.js
@@ -62,10 +62,15 @@ describe('Dropdown', () => {
 	});
 
 	describe('toggles drop down menu via `aria-expanded`', () => {
-		it('repositions dropdown menu if it doesnt fit to the right of the window', () => {
-			navItems[1].querySelector('li').style.width = window.innerWidth + 1;
+		it('repositions dropdown menu if it doesnt fit to the right of the window but can fit to the left', (done) => {
+			const subItem = navItems[1].querySelector('li');
+			navItems[1].style['margin-left'] = (window.innerWidth / 2) + 'px';
+			subItem.style['width'] = (window.innerWidth / 2) + 'px';
 			click(navItems[1], 'button');
-			proclaim.isTrue(navItems[1].lastElementChild.classList.contains('o-header-services__list--right'));
+			setTimeout(() => {
+				proclaim.isTrue(navItems[1].lastElementChild.classList.contains('o-header-services__list--right'));
+				done();
+			}, 100);
 		});
 	});
 });


### PR DESCRIPTION
- Updates the design of the drawer to accommodate an ad (or other content) above the nav.
- Adds new variables to configure the header for fDi
    - text-hover-color
    - drawer-background
    - drawer-button-background
    - drawer-text-hover-color
    - drawer-nav-hover-background
- Adds support to switch to the drawer at a custom breakpoint
- Removes some tests. These did not work, I'd like to improve our test coverage separately. More details below.

**Example fDi Config**

To test an FDi-like design, temporarily replace brand config for the internal brand:

```scss
@if oBrandGetCurrentBrand() == 'internal' {
	$fdi-blue: #1173C1;
	$background-grey: #ECECEC;
	$fdi-border: #979797;
	@include oBrandDefine('o-header-services', 'internal', (
		'variables': (
			logo: null,
			top-text: oColorsGetPaletteColor('black'),
			top-background: oColorsGetPaletteColor('white'),
			nav-text: oColorsGetPaletteColor('black'),
			nav-background: oColorsGetPaletteColor('white'),
			nav-border: $fdi-border,
			nav-hover-background: $background-grey,
			nav-underline-color: $fdi-blue,
			arrow-icon-color: oColorsGetPaletteColor('black'),
			arrow-icon-hover-color: $fdi-blue,
			button-hover-color: $background-grey,

			text-hover-color: $fdi-blue,
			drawer-background: $background-grey,
			drawer-button-background: darken($background-grey, 10),
			drawer-text-hover-color: #FFFFFF,
			drawer-nav-hover-background: $fdi-blue,
			primary-nav-item-horizontal-padding: 10px
		),
		'supports-variants': ()
	));
}
}

```

**Why were the tests borked?**
- `window.resizeTo` seemed to have no effect. 
- Previously `oGrid` was used to check the current layout (M,L,XL, etc) to  decide when to enable the drawer. As the test CSS was included in the body, `document.body.innerHTML = fixtures.withPrimaryNav;` removed the CSS and `oGrid` returned `undefined` for the layout.