### PR TITLE
Fix bug where path relative logos would get returned the wrong string.

### DIFF
--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -1,5 +1,5 @@
 @function _oHeaderServicesLogo($logo) {
-	@if str-index($logo, 'https://') == 1 or str-index($logo, 'http://') == 1 or str-index($logo, 'data:') == 1 or str-index($logo, './') == 0 or str-index($logo, '/') == 1 {
+	@if str-index($logo, 'https://') == 1 or str-index($logo, 'http://') == 1 or str-index($logo, 'data:') == 1 or str-index($logo, './') == 1 or str-index($logo, '/') == 1 {
 		@return $logo;
 	} @else {
 		@return 'https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1:#{$logo}?source=o-header-services&format=svg&width=55';


### PR DESCRIPTION
They should have their logo returned as-is, currently the bug makes the function return the origami-image-service url instead.