### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,27 @@ $o-brand: whitelabel;
 ));
 ```
 
-You can see all of the variables that are available for customising under `whitelabel` in the [brand SCSS file](../src/scss/_brand.scss#L70).
+We recommend customising the following brand variables:
+
+- top-text
+- top-background
+- nav-text
+- nav-background
+- nav-border
+- nav-hover-background
+- nav-underline-color
+- arrow-icon-color
+- arrow-icon-hover-color
+- button-hover-color
+
+In addition, the following brand variables may also be customised:
+
+- text-hover-color
+- drawer-background
+- drawer-button-background
+- drawer-text-hover-color
+- drawer-nav-hover-background
+- primary-nav-item-horizontal-padding
 
 ## JavaScript
 

--- a/main.scss
+++ b/main.scss
@@ -31,7 +31,7 @@
 ///			'types': ('primary-nav'),
 ///			'features': ('drop-down'),
 ///			'logo': 'origami',
-///         'drawer-breakpoint': 'L'
+///			'drawer-breakpoint': 'L'
 ///		))
 @mixin oHeaderServices($opts: (
 	'types': ('primary-nav', 'secondary-nav', 'b2b', 'b2c'),

--- a/main.scss
+++ b/main.scss
@@ -18,13 +18,20 @@
 @import 'src/scss/secondary-nav';
 
 /// Outputs all features and styles available to o-header-services
-/// @param {Map} $opts ['types':('primary-nav', 'secondary-nav', 'b2b', 'b2c'), 'features': ('bleed', 'drop-down'), 'logo': default to ft-logo depending on brand (pink or white)]
+/// @param {Map} $opts ['types':('primary-nav', 'secondary-nav', 'b2b', 'b2c'), 'features': ('bleed', 'drop-down'), 'drawer-breakpoint': 'M', 'logo': default to ft-logo depending on brand (pink or white)]
 /// @access public
-/// @example scss
+/// @example scss This example outputs styles for a header with an origami logo, and a primary navigation with dropdowns.
 ///		@include oHeaderServices($opts: (
 ///			'types': ('primary-nav'),
 ///			'features': ('drop-down'),
 ///			'logo': 'origami'
+///		))
+/// @example scss This example changes the breakpoint at which the primary navigation is hidden behind a drawer.
+///		@include oHeaderServices($opts: (
+///			'types': ('primary-nav'),
+///			'features': ('drop-down'),
+///			'logo': 'origami',
+///         'drawer-breakpoint': 'L'
 ///		))
 @mixin oHeaderServices($opts: (
 	'types': ('primary-nav', 'secondary-nav', 'b2b', 'b2c'),


### PR DESCRIPTION
- Not all available brand variables are documented in the code, they're their to customise the whitelabel brand, so add them to the readme explicitly.
- The `drawer-breakpoint` option was only documented in the readme. This documents in in codedocs too.