### PR TITLE
Add brackets around example $opts maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,10 @@ In this example we include only the styles for a [primary navigation](#primary-n
 ```scss
 	@import 'o-header-services/main';
 
-	@include oHeaderServices($opts:
+	@include oHeaderServices($opts: (
 		'types': ('primary-nav', 'bleed');
 		'logo': 'origami'
-	);
+	));
 
 	// Will output styles for a bleed header with a primary navigation and the Origami logo
 ```


### PR DESCRIPTION
Code copied from this failed to compile using `dart-sass`, with this unhelpful error:

```
    ERROR in ./src/app.scss (./node_modules/css-loader/dist/cjs.js??ref--4-1!./node_modules/postcss-loader/src??postcss!./node_modules/sass-loader/lib/loader.js??ref--4-3!./src/app.scss)
    Module build failed (from ./node_modules/sass-loader/lib/loader.js):

        $opts: types:
                ^
          Expected ")".
       ╷
    13 │     $opts: types:
       │                 ^
       ╵
      src/styles/_header.scss 13:14  root stylesheet
      stdin 27:9                     root stylesheet
```