### PR TITLE
Improve progressive font loading.

### DIFF
--- a/src/scss/_drop-down.scss
+++ b/src/scss/_drop-down.scss
@@ -43,7 +43,7 @@
 
 	// Drop down list.
 	ul[data-o-header-services-level="2"] {
-		@include oTypographySize(-1);
+		@include oTypographySans(-1);
 		background: _oHeaderServicesGet('nav-background');
 		border: 1px solid _oHeaderServicesGet('nav-border');
 		box-sizing: border-box;

--- a/src/scss/_top.scss
+++ b/src/scss/_top.scss
@@ -68,17 +68,13 @@
 	}
 
 	.o-header-services__product-name {
-		@include oTypographySize($scale: 2);
+		@include oTypographySans($scale: (default: 2, M: 4));
 		@include oTypographyBold('sans');
 		text-overflow: ellipsis;
-
-		@include oGridRespondTo(M) {
-			@include oTypographySize($scale: 4);
-		}
 	}
 
 	.o-header-services__product-tagline {
-		@include oTypographySize($scale: 3);
+		@include oTypographySans($scale: 3);
 		margin-left: $_o-header-services-padding;
 		text-overflow: ellipsis;
 		overflow: hidden;


### PR DESCRIPTION
Use `oTypographySans` over `oTypographySize` as this supports progressive font loading. Related o-typography issue: https://github.com/Financial-Times/o-typography/issues/184

Before:
![before](https://user-images.githubusercontent.com/10405691/54279925-28947000-458e-11e9-8aa1-331fbddf8fc7.gif)

After (note the title jumps in size significantly less):
![now](https://user-images.githubusercontent.com/10405691/54279936-2c27f700-458e-11e9-8fa3-2e33caeb1d4a.gif)
