### PR TITLE
Prevent flash of the drawer on mobile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For an example and markup, see the [primary navigation in the Origami Registry](
 
 ### Core Experience Of The Drawer
 
-Small screen users should still be able to access the contents of the drawer even if their browser doesn't cut the mustard or the JavaScript has failed to load. In this case we recommend you have the contents of the drawer at the bottom of the page in a footer that is only visible if the body has a `.core` class. In core experience the hamburger menu links to an anchor at the bottom of the page.
+Small screen users should still be able to access the contents of the drawer even if their browser doesn't [cut the mustard](https://origami.ft.com/docs/components/compatibility/#cuts-the-mustard) or the JavaScript has failed to load. In this case we recommend you have the contents of the drawer at the bottom of the page in a footer that is only visible if the body has a `.core` class. In core experience the hamburger menu links to an anchor at the bottom of the page.
 
 ### Primary Navigation With Drop Down
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,11 @@ If you are using extra content (such as a 'Sign in' link), that will be pulled i
 
 For an example and markup, see the [primary navigation in the Origami Registry](https://registry.origami.ft.com/components/o-header-services@3.2.10#demo-header-with-primary-navigation).
 
-### Primary Navigation with drop down
+### Core Experience Of The Drawer
+
+Small screen users should still be able to access the contents of the drawer even if their browser doesn't cut the mustard or the JavaScript has failed to load. In this case we recommend you have the contents of the drawer at the bottom of the page in a footer that is only visible if the body has a `.core` class. In core experience the hamburger menu links to an anchor at the bottom of the page.
+
+### Primary Navigation With Drop Down
 
 The primary navigation can also handle dropdown menus. These menus are hidden behind a button that lives beside the navigation item that it is pertinent to.
 

--- a/demos/src/header.mustache
+++ b/demos/src/header.mustache
@@ -1,14 +1,12 @@
 
 <header class="o-header-services {{#modifier}}o-header-services--{{modifier}}{{/modifier}}" data-o-component="o-header-services">
 	<div class="o-header-services__top">
-			{{#primary-navigation}}
-			<div class="o-header-services__hamburger">
-				<!-- Link to a fallback nav when using a drawer with hamburger icon. -->
-				<a class="o-header-services__hamburger-icon" href="#core-nav-fallback" role="button">
-					<span class="o-header-services__visually-hidden">Open primary navigation</span>
-				</a>
-			</div>
-			{{/primary-navigation}}
+		<!-- Link to a fallback nav for the core experience when using a drawer and hamburger icon. -->
+		<div class="o-header-services__hamburger">
+			<a class="o-header-services__hamburger-icon" href="#core-nav-fallback" role="button">
+				<span class="o-header-services__visually-hidden">Open primary navigation</span>
+			</a>
+		</div>
 		<div class="o-header-services__logo"></div>
 		<div class="o-header-services__title">
 			<a class="o-header-services__product-name" href="/">Tool or Service name</a>

--- a/demos/src/header.mustache
+++ b/demos/src/header.mustache
@@ -3,7 +3,8 @@
 	<div class="o-header-services__top">
 			{{#primary-navigation}}
 			<div class="o-header-services__hamburger">
-				<a class="o-header-services__hamburger-icon" href="#" role="button">
+				<!-- Link to a fallback nav when using a drawer with hamburger icon. -->
+				<a class="o-header-services__hamburger-icon" href="#core-nav-fallback" role="button">
 					<span class="o-header-services__visually-hidden">Open primary navigation</span>
 				</a>
 			</div>

--- a/main.scss
+++ b/main.scss
@@ -55,7 +55,7 @@
 	@include _oHeaderServicesTop($logo, $drawer-breakpoint);
 
 	@if index($types, 'primary-nav') {
-		@include _oHeaderServicesPrimaryNav($drop-down);
+		@include _oHeaderServicesPrimaryNav($drawer-breakpoint, $drop-down);
 	}
 
 	@if index($types, 'secondary-nav') {

--- a/origami.json
+++ b/origami.json
@@ -24,7 +24,8 @@
 	},
 	"demosDefaults": {
 		"dependencies": [
-			"o-fonts@^3.0.0"
+			"o-fonts@^3.0.0",
+			"o-normalise@^1.0.0"
 		],
 		"documentClasses": "core",
 		"sass": "demos/src/main.scss",

--- a/src/js/drawer.js
+++ b/src/js/drawer.js
@@ -7,13 +7,34 @@ class Drawer {
 	 */
 	constructor(headerEl) {
 		this.headerEl = headerEl;
-		this.nav = headerEl.querySelector('.o-header-services__primary-nav');
 		this.class = {
 			drawer: 'o-header-services__primary-nav--drawer',
 			open: 'o-header-services__primary-nav--open'
 		};
 
-		if (!this.nav) { return; }
+		this.relatedContent = headerEl.querySelector('.o-header-services__related-content');
+		this.nav = headerEl.querySelector('.o-header-services__primary-nav');
+
+		// If the primary nav `nav` does not exist, but related content does,
+		// then create an empty primary nav which functions as a draw for
+		// related content on mobile.
+		if (!this.nav && this.relatedContent) {
+			this.nav = document.createElement('div');
+			this.nav.classList.add('o-header-services__primary-nav');
+			this.nav.setAttribute('aria-label', 'primary navigation');
+			this.nav.setAttribute('aria-hidden', 'true'); // Hidden until related content is added the drawer.
+
+			this.navList = document.createElement('ul');
+			this.navList.classList.add('o-header-services__primary-nav-list');
+			this.nav.appendChild(this.navList);
+
+			this.headerEl.appendChild(this.nav);
+		}
+
+		// If there's no primary nav and we didn't create one exit.
+		if (!this.nav) {
+			return;
+		}
 
 		this.navList = this.nav.querySelector('.o-header-services__primary-nav-list');
 
@@ -103,7 +124,7 @@ class Drawer {
 	 * Shift related content (sign in, etc) between drawer and header title section
 	 */
 	_shiftRelatedContentList (shiftItems) {
-		let relatedContent = this.headerEl.querySelector('.o-header-services__related-content');
+		let relatedContent = this.relatedContent;
 
 		if (!relatedContent) { return; }
 

--- a/src/js/drawer.js
+++ b/src/js/drawer.js
@@ -59,6 +59,7 @@ class Drawer {
 		}
 
 		if ((e.type === 'click' && [this.nav, this.burger, this.drawerCloseButton].includes(e.target))) {
+			e.preventDefault();
 			this.toggleDrawer();
 		}
 	}

--- a/src/scss/_drawer.scss
+++ b/src/scss/_drawer.scss
@@ -1,8 +1,15 @@
 /// @access private
 /// @outputs styling for the drawer
+/// @param {String} $draw-breakpoint At what breakpoint to show the draw hamburger.
 /// @param {Boolean} $drop-down - Whether to include styles to support the dropdown nav.
 // sass-lint:disable no-qualifying-elements
-@mixin _oHeaderServicesDrawer($drop-down: true) {
+@mixin _oHeaderServicesDrawer($draw-breakpoint, $drop-down) {
+	.o-header-services__primary-nav {
+		@include oGridRespondTo($until: $draw-breakpoint) {
+			display: none;
+		}
+	}
+
 	.o-header-services__primary-nav.o-header-services__primary-nav--drawer {
 		// Drawer background.
 		background-color: rgba(0, 0, 0, 0.8);
@@ -12,6 +19,7 @@
 		right: 0;
 		bottom: 0;
 		visibility: hidden;
+		display: block;
 		transition:
 			visibility 0.01s linear,
 			opacity 0.5s $o-visual-effects-transition-fade;

--- a/src/scss/_primary-nav.scss
+++ b/src/scss/_primary-nav.scss
@@ -1,7 +1,8 @@
 /// @access private
 /// @outputs styling for primary nav
+/// @param {String} $draw-breakpoint At what breakpoint to show the draw hamburger.
 /// @param {Boolean} $drop-down - Whether to include styles to support the dropdown nav.
-@mixin _oHeaderServicesPrimaryNav($drop-down) {
+@mixin _oHeaderServicesPrimaryNav($drawer-breakpoint, $drop-down) {
 	.o-header-services__primary-nav {
 		position: relative;
 		background-color: _oHeaderServicesGet('nav-background');
@@ -66,5 +67,5 @@
 		}
 	}
 
-	@include _oHeaderServicesDrawer($drop-down);
+	@include _oHeaderServicesDrawer($drawer-breakpoint, $drop-down);
 };

--- a/src/scss/_secondary-nav.scss
+++ b/src/scss/_secondary-nav.scss
@@ -121,6 +121,10 @@
 		}
 	}
 
+	.core .o-header-services__scroll-button {
+		display: none;
+	}
+
 	.o-header-services__scroll-button--left {
 		@include oButtonsIconButton(
 			$icon-name: 'arrow-left',

--- a/src/scss/_top.scss
+++ b/src/scss/_top.scss
@@ -85,31 +85,23 @@
 	}
 
 	.o-header-services__related-content {
-		margin: 0 0 0 auto;
-		padding: oTypographySpacingSize(3)/2 $_o-header-services-padding;
-		display: flex;
+		display: none;
+
+		@include oGridRespondTo($from: $draw-breakpoint) {
+			display: flex;
+			margin: 0 0 0 auto;
+			padding: oTypographySpacingSize(3)/2 $_o-header-services-padding;
+		}
 
 		li {
 			background-color: _oHeaderServicesGet('top-background');
 
-			@if _oHeaderServicesGet('nav-background') == _oHeaderServicesGet('nav-hover-background') {
-				&:hover:before {
-					content: none;
-				}
-			}
-
 			a {
 				@include oTypographyBold('sans');
-				margin: 0;
 				color: _oHeaderServicesGet('top-text');
-
-
-				@include oGridRespondTo($from: $draw-breakpoint) {
-					display: block;
-					padding: $_o-header-services-padding oTypographySpacingSize(3);
-					margin: 0;
-				}
-
+				display: inline-block;
+				padding: $_o-header-services-padding oTypographySpacingSize(3);
+				margin: 0;
 
 				&:hover {
 					text-decoration: underline;


### PR DESCRIPTION
The core experience of o-header-services is a little broken.
- There's a flash of the drawer as the JS loads on each page.
- The drop down is detatched from the menu item when items are
  on multiple lines (due to the drawer not initalising).
- The scroll arrows show even though they don't work.

<img width="447" alt="Screenshot 2019-04-24 at 14 41 03" src="https://user-images.githubusercontent.com/10405691/56664816-b80a6400-66a0-11e9-9f93-e2c0815cecbf.png">

This PR restores the core behavior of the previous major
version (v2):

- Hide primary nav items for the core experience when they
  should be behind the drawer. There should be a fallback
provided using the hamburger's anchor. This behavior is
consistent with the demos and previous major (v2), I've
reinstated our [previous recommendations](https://github.com/Financial-Times/o-header-services/tree/v2.3.4#core-experience-of-the-drawer) to the README.
- Hide the scroll arrows within the secondary nav for the core
  experience.
- Remove some redundant CSS along the way.