### PR TITLE
 Fix mobile experience for headers with related content.

### DIFF
--- a/demos/src/header.mustache
+++ b/demos/src/header.mustache
@@ -1,14 +1,12 @@
 
 <header class="o-header-services {{#modifier}}o-header-services--{{modifier}}{{/modifier}}" data-o-component="o-header-services">
 	<div class="o-header-services__top">
-			{{#primary-navigation}}
-			<div class="o-header-services__hamburger">
-				<!-- Link to a fallback nav when using a drawer with hamburger icon. -->
-				<a class="o-header-services__hamburger-icon" href="#core-nav-fallback" role="button">
-					<span class="o-header-services__visually-hidden">Open primary navigation</span>
-				</a>
-			</div>
-			{{/primary-navigation}}
+		<!-- Link to a fallback nav for the core experience when using a drawer and hamburger icon. -->
+		<div class="o-header-services__hamburger">
+			<a class="o-header-services__hamburger-icon" href="#core-nav-fallback" role="button">
+				<span class="o-header-services__visually-hidden">Open primary navigation</span>
+			</a>
+		</div>
 		<div class="o-header-services__logo"></div>
 		<div class="o-header-services__title">
 			<a class="o-header-services__product-name" href="/">Tool or Service name</a>

--- a/origami.json
+++ b/origami.json
@@ -24,7 +24,8 @@
 	},
 	"demosDefaults": {
 		"dependencies": [
-			"o-fonts@^3.0.0"
+			"o-fonts@^3.0.0",
+			"o-normalise@^1.0.0"
 		],
 		"documentClasses": "core",
 		"sass": "demos/src/main.scss",

--- a/src/js/drawer.js
+++ b/src/js/drawer.js
@@ -7,13 +7,34 @@ class Drawer {
 	 */
 	constructor(headerEl) {
 		this.headerEl = headerEl;
-		this.nav = headerEl.querySelector('.o-header-services__primary-nav');
 		this.class = {
 			drawer: 'o-header-services__primary-nav--drawer',
 			open: 'o-header-services__primary-nav--open'
 		};
 
-		if (!this.nav) { return; }
+		this.relatedContent = headerEl.querySelector('.o-header-services__related-content');
+		this.nav = headerEl.querySelector('.o-header-services__primary-nav');
+
+		// If the primary nav `nav` does not exist, but related content does,
+		// then create an empty primary nav which functions as a draw for
+		// related content on mobile.
+		if (!this.nav && this.relatedContent) {
+			this.nav = document.createElement('div');
+			this.nav.classList.add('o-header-services__primary-nav');
+			this.nav.setAttribute('aria-label', 'primary navigation');
+			this.nav.setAttribute('aria-hidden', 'true');
+
+			this.navList = document.createElement('ul');
+			this.navList.classList.add('o-header-services__primary-nav-list');
+			this.nav.appendChild(this.navList);
+
+			this.headerEl.appendChild(this.nav);
+		}
+
+		// If there's no primary nav and we didn't create one exit.
+		if (!this.nav) {
+			return;
+		}
 
 		this.navList = this.nav.querySelector('.o-header-services__primary-nav-list');
 
@@ -103,7 +124,7 @@ class Drawer {
 	 * Shift related content (sign in, etc) between drawer and header title section
 	 */
 	_shiftRelatedContentList (shiftItems) {
-		let relatedContent = this.headerEl.querySelector('.o-header-services__related-content');
+		let relatedContent = this.relatedContent;
 
 		if (!relatedContent) { return; }
 

--- a/src/js/drawer.js
+++ b/src/js/drawer.js
@@ -22,7 +22,7 @@ class Drawer {
 			this.nav = document.createElement('div');
 			this.nav.classList.add('o-header-services__primary-nav');
 			this.nav.setAttribute('aria-label', 'primary navigation');
-			this.nav.setAttribute('aria-hidden', 'true');
+			this.nav.setAttribute('aria-hidden', 'true'); // Hidden until related content is added the drawer.
 
 			this.navList = document.createElement('ul');
 			this.navList.classList.add('o-header-services__primary-nav-list');


### PR DESCRIPTION
Builds on (please review first): https://github.com/Financial-Times/o-header-services/pull/97
Relates to this issue: https://github.com/Financial-Times/o-header-services/pull/97

When related content is used without a primary nav, they become 
squashed and unformatted on mobile viewports instead of being 
hidden as with the previous major v2 (to be shown behind the draw).

<img width="461" alt="Screenshot 2019-04-24 at 15 40 43" src="https://user-images.githubusercontent.com/10405691/56668841-23a3ff80-66a8-11e9-86cc-dadc19b932c2.png">

This PR enables related content to be behind a drawer on mobile
when there is no primary nav. Note: it requires a burger element.