### PR TITLE
Fix drawer/dropdown race condition.

### DIFF
--- a/src/js/drawer.js
+++ b/src/js/drawer.js
@@ -92,7 +92,7 @@ class Drawer {
 	 * If the burger element is visible, the drawer is enabled.
 	 */
 	get enabled () {
-		return this.nav && this.burger && this.burger.offsetHeight !== 0
+		return this.nav && this.burger && this.burger.offsetHeight !== 0;
 	}
 
 	/**

--- a/src/js/drawer.js
+++ b/src/js/drawer.js
@@ -54,7 +54,7 @@ class Drawer {
 			}
 		}
 
-		this.debouncedRender = oUtils.debounce(() => this.render(), 100);
+		this.debouncedRender = oUtils.debounce(() => this.render(), 33);
 		this.burger = this.headerEl.querySelector('.o-header-services__hamburger-icon');
 		if (this.burger) {
 			this.burger.addEventListener('click', this);
@@ -88,24 +88,28 @@ class Drawer {
 	}
 
 	/**
+	 * Check if the drawer is currently enabled.
+	 * If the burger element is visible, the drawer is enabled.
+	 */
+	get enabled () {
+		return this.nav && this.burger && this.burger.offsetHeight !== 0
+	}
+
+	/**
 	 * Drawer rendering
 	 */
 	render () {
-		// If burger is visible, render the drawer.
-		// https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetHeight
-		const enableDrawer = this.burger && this.burger.offsetHeight !== 0;
-
-		if (enableDrawer) {
+		if (this.enabled) {
 			this.nav.addEventListener('click', this);
 		} else {
 			this.nav.removeEventListener('click', this);
 		}
 
-		this._shiftRelatedContentList(enableDrawer);
-		this.nav.classList.toggle(this.class.drawer, enableDrawer);
-		this.nav.classList.toggle(this.class.open, !enableDrawer);
+		this._shiftRelatedContentList(this.enabled);
+		this.nav.classList.toggle(this.class.drawer, this.enabled);
+		this.nav.classList.toggle(this.class.open, !this.enabled);
 
-		this.nav.setAttribute('aria-hidden', enableDrawer);
+		this.nav.setAttribute('aria-hidden', this.enabled);
 	}
 
 	/**

--- a/src/js/drop-down.js
+++ b/src/js/drop-down.js
@@ -1,10 +1,14 @@
+import * as oUtils from 'o-utils';
+
 class DropDown {
 	/**
 	 * Class constructor
-	 * @param {HTMLElement} [headerEl] - The component element in the DOM
+	 * @param {HTMLElement} headerEl - The component element in the DOM
+	 * @param {Drawer|null} drawer [null] - The drawer that this drop down belongs to if any.
 	 */
-	constructor (headerEl) {
+	constructor(headerEl, drawer = null) {
 		this.primaryNav = headerEl.querySelector('.o-header-services__primary-nav');
+		this.drawer = drawer;
 
 		this.navItems = [...headerEl.querySelectorAll('[data-o-header-services-level="1"]')];
 		this.navItems.forEach(item => {
@@ -14,7 +18,7 @@ class DropDown {
 		// the event listener is added to the body here to handle cases where a
 		// user might click anywhere else on the body to collapse open dropdowns
 		document.body.addEventListener('click', this);
-		window.addEventListener('resize', this);
+		window.addEventListener('resize', oUtils.debounce(() => this.reset(), 33));
 		window.addEventListener('keydown', this);
 	}
 
@@ -40,17 +44,19 @@ class DropDown {
 			}
 
 			e.stopPropagation();
-		} else if (e.type === 'resize' || (e.key === 'Escape')) {
+		}
+
+		if (e.key === 'Escape') {
 			this.reset();
 		}
 	}
 
 	/**
-	 * Checks if primary nav is a drawer
+	 * Checks if primary nav is in a drawer
 	 * This boolean will change the drop down behaviour.
 	 */
 	isDrawer() {
-		return this.primaryNav.classList.contains('o-header-services__primary-nav--drawer');
+		return this.drawer && this.drawer.enabled;
 	}
 
 	/**

--- a/src/js/header.js
+++ b/src/js/header.js
@@ -8,8 +8,8 @@ class HeaderServices {
 	 * @param {HTMLElement} [headerEl] - The component element in the DOM
 	 */
 	constructor (headerEl) {
-		new Drawer(headerEl);
-		new DropDown(headerEl);
+		const drawer = new Drawer(headerEl);
+		new DropDown(headerEl, drawer);
 		new Scroll(headerEl);
 	}
 


### PR DESCRIPTION
This addressed https://github.com/Financial-Times/o-header-services/issues/106.

The Dropdown checks if the drawer is enabled by looking for a CSS
class. The Drawer adds the CSS class when it should be enabled.
There was a race condition, where the Drawer would add the class
on resize with a debounced event listener after the Dropdown
has checked for the class.

This PR adds a debounce to the Dropdown resize for performance
purposes, but a race condition could still exist. So the Drawer
is passed to the Dropdown so the Dropdown may check the status
of the Drawer directly without an implicit dependency.

There is a "flash" during the transition as the nav item still
animates -- this is a [separate issue](https://github.com/Financial-Times/o-header-services/issues/107).
