### PR TITLE
Use clip-path over z-index to hide animating dropdown.

### DIFF
--- a/src/scss/_drawer.scss
+++ b/src/scss/_drawer.scss
@@ -20,9 +20,9 @@
 		bottom: 0;
 		visibility: hidden;
 		display: block;
-		transition:
-			visibility 0.01s linear,
-			opacity 0.5s $o-visual-effects-transition-fade;
+		transition: visibility 0.01s linear, opacity 0.5s $o-visual-effects-transition-fade;
+		// So the drawer stays on top of other elements.
+		z-index: 1;
 
 		// Drawer nav.
 		.o-header-services__primary-nav-list {
@@ -86,7 +86,6 @@
 				width: 100%;
 				// Reset the dropdown styles now they are in a drawer.
 				transition: none;
-				z-index: 0;
 				max-width: none;
 				white-space: normal;
 				a {

--- a/src/scss/_drop-down.scss
+++ b/src/scss/_drop-down.scss
@@ -2,11 +2,6 @@
 /// @access private
 /// @outputs styling for primary navigation drop down menus
 @mixin _oHeaderServicesDropDown() {
-	// So the dropdown stays above other elements.
-	.o-header-services__primary-nav {
-		z-index: 1;
-	}
-
 	// Drop down button.
 	.o-header-services__drop-down-button {
 		background-color: transparent;
@@ -46,14 +41,17 @@
 		@include oTypographySans(-1);
 		background: _oHeaderServicesGet('nav-background');
 		border: 1px solid _oHeaderServicesGet('nav-border');
+		left: -1px;
 		box-sizing: border-box;
 		padding-left: 0;
 		position: absolute;
+		// So the dropdown appears above other elements.
+		// But does not obscure its button as it animates down.
+		z-index: 1;
+		clip-path: inset(10.5% 0 0 0);
 		opacity: 0;
 		transform: translateY(-10%);
-		transition: opacity 0.1s linear, transform 0.1s ease-in;
-		left: -1px;
-		z-index: -1; // So the dropdown doesn't cover the link/button whilst animating.
+		transition: clip-path 0.1s linear, opacity 0.1s linear, transform 0.1s ease-in;
 
 		// The dropdown list is inviisble when closed.
 		// This is so it doesn't block interaction with other elements.
@@ -77,7 +75,6 @@
 	// Drop down list (opened state).
 	.core li[data-o-header-services-level]:hover,
 	li[aria-expanded=true] {
-
 		// Reveal the dropdown.
 		ul[data-o-header-services-level] {
 			height: auto;
@@ -86,6 +83,7 @@
 			}
 			transform: translateY(0);
 			opacity: 1;
+			clip-path: inset(0 0 0 0);
 		}
 
 		// Reveal visually hidden elements within the dropdown to screen readers.

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -4,10 +4,8 @@ $_o-header-services-padding: oGridGutter();
 
 $_o-header-services-top-bar-short: oSpacingByIncrement(11);
 
-$_o-header-services-primary-nav-z-index: 1;
-
- $_o-header-services-top-icon-size: oSpacingByIncrement(10);
- $_o-header-services-button-icon-size: oSpacingByIncrement(6);
+$_o-header-services-top-icon-size: oSpacingByIncrement(10);
+$_o-header-services-button-icon-size: oSpacingByIncrement(6);
 
 $_o-header-services-button-theme: (
 	background: _oHeaderServicesGet('nav-text'),


### PR DESCRIPTION
The dropdown transitions down from above its nav item, so it
appears to come from the nav item. The nav item has a higher
z-index so the dropdown does not obscure the button and appears to
come from behind or within.

As the nav item had a higher z-index than their dropdown, when
nav items end up on two rows the dropdown from items in the
first row are hidden by the second.

Removing the z-index from the nav items fixes this but leaves
a small visual oddity as the dropdown transitions. To improve
this for modern browsers I've added a clip-path (clip with
greater browser support does not allow percentages).

Resolves: https://github.com/Financial-Times/o-header-services/issues/105

Without the clip path:
![Kapture 2019-07-04 at 13 07 17](https://user-images.githubusercontent.com/10405691/60666798-d4c0d600-9e5f-11e9-943f-2c66c7f31d64.gif)

With the clip path:
![Kapture 2019-07-04 at 13 31 00](https://user-images.githubusercontent.com/10405691/60666869-076ace80-9e60-11e9-8990-48ee3dbd6291.gif)
