### PR TITLE
Do not add redundant `o-header-services__primary-nav--open` class

### DIFF
--- a/src/js/drawer.js
+++ b/src/js/drawer.js
@@ -107,7 +107,6 @@ class Drawer {
 
 		this._shiftRelatedContentList(this.enabled);
 		this.nav.classList.toggle(this.class.drawer, this.enabled);
-		this.nav.classList.toggle(this.class.open, !this.enabled);
 
 		this.nav.setAttribute('aria-hidden', this.enabled);
 	}

--- a/test/js/drawer.test.js
+++ b/test/js/drawer.test.js
@@ -23,9 +23,9 @@ describe('Drawer', () => {
 	});
 
 	context('on viewports above 740px', () => {
-		it('primary nav is visibile', (done) => {
+		it('drawer is not enabled', (done) => {
 			setTimeout(() => {
-				proclaim.isTrue(primaryNav.classList.contains('o-header-services__primary-nav--open'));
+				proclaim.isFalse(primaryNav.classList.contains('o-header-services__primary-nav--drawer'));
 				done();
 			}, 100);
 		});


### PR DESCRIPTION
The class `o-header-services__primary-nav--open` has no effect
if the draw is not enabled.