### PR TITLE
Prevent dropdown "flash" when drawer is enabled/disabled on resize.

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -21,7 +21,7 @@
 			"Array.from"
 		],
 		"optional": [
-			"ResizeObserverEntry"
+			"ResizeObserver"
 		]
 	},
 	"ci": {

--- a/origami.json
+++ b/origami.json
@@ -19,6 +19,9 @@
 		"required": [
 			"customevent",
 			"Array.from"
+		],
+		"optional": [
+			"ResizeObserverEntry"
 		]
 	},
 	"ci": {

--- a/src/scss/_drop-down.scss
+++ b/src/scss/_drop-down.scss
@@ -96,5 +96,17 @@
 			transform: rotate(-180deg);
 		}
 	}
+
+	// Used to disable transitions between drawer states on viewport
+	// resize. They should only happen on direct user interaction.
+	.o-header-services--disable-transition {
+		.o-header-services__drop-down-button:after {
+			transition: none;
+		}
+		// Drop down list.
+		ul[data-o-header-services-level="2"] {
+			transition: none;
+		}
+	}
 }
 // sass-lint:enable no-qualifying-elements

--- a/test/js/drop-down.test.js
+++ b/test/js/drop-down.test.js
@@ -51,13 +51,21 @@ describe('Dropdown', () => {
 			proclaim.isTrue(attribute);
 		});
 
-		it('hides all menus if click outside of nav items', () => {
+		it('hides all menus if click outside of nav items', (done) => {
 			click(navItems[0], 'button');
-			attribute = navItems[0].getAttribute('aria-expanded') === 'true';
-			proclaim.isTrue(attribute);
-			click(document, 'body');
-			attribute = navItems[0].getAttribute('aria-expanded') === 'false';
-			proclaim.isTrue(attribute);
+			setTimeout(() => {
+				// Assert expanded dropdown
+				attribute = navItems[0].getAttribute('aria-expanded') === 'true';
+				proclaim.isTrue(attribute);
+				// Click on body
+				click(document, 'body');
+				setTimeout(() => {
+					// Assert collapsed dropdown
+					attribute = navItems[0].getAttribute('aria-expanded') === 'false';
+					proclaim.isTrue(attribute);
+					done();
+				}, 100); // allow time for requestAnimationFrame
+			}, 100); // allow time for requestAnimationFrame
 		});
 	});
 


### PR DESCRIPTION
Fixes: https://github.com/Financial-Times/o-header-services/issues/107
Relates to Slack conversion:
https://financialtimes.slack.com/archives/C02FU5ARJ/p1585319930024200

gif of before, note the drop down flash when transitioning to a desktop view:
![Kapture 2020-03-30 at 14 46 07](https://user-images.githubusercontent.com/10405691/77919603-4c0f8300-7295-11ea-9be2-d28d8d81be19.gif)
