### PR TITLE
Stop using magic webpack imports

### DIFF
--- a/test/js/drawer.test.js
+++ b/test/js/drawer.test.js
@@ -1,6 +1,6 @@
-/* eslint-env mocha*/
+/* eslint-env mocha */
+/* global proclaim */
 
-import proclaim from 'proclaim';
 import HeaderServices from '../../src/js/header';
 import * as fixtures from '../helpers/fixtures';
 

--- a/test/js/drop-down.test.js
+++ b/test/js/drop-down.test.js
@@ -1,6 +1,6 @@
-/* eslint-env mocha*/
+/* eslint-env mocha */
+/* global proclaim */
 
-import proclaim from 'proclaim';
 import HeaderServices from '../../src/js/header';
 import * as fixtures from '../helpers/fixtures';
 

--- a/test/js/header.test.js
+++ b/test/js/header.test.js
@@ -1,6 +1,6 @@
-/* eslint-env mocha*/
+/* eslint-env mocha */
+/* global proclaim */
 
-import proclaim from 'proclaim';
 import HeaderServices from '../../src/js/header';
 
 describe('Header instance', () => {


### PR DESCRIPTION
Stop using the magic imports for proclaim and sinon and pull them from the global because that's where Karma has added them. This is required for obt v10 to be released.