### PR TITLE
Correct dropdown border style within the drawer

### DIFF
--- a/src/scss/_drawer.scss
+++ b/src/scss/_drawer.scss
@@ -62,7 +62,7 @@
 				padding: 0 0.4375rem;
 				height: oSpacingByIncrement(10);
 				border: 1px solid _oHeaderServicesGet('nav-border');
-				border-top: 0px;
+				border-top-color: transparent;
 			}
 
 			// Override the background colour of the draw's dropdown button.

--- a/src/scss/_drop-down.scss
+++ b/src/scss/_drop-down.scss
@@ -28,7 +28,7 @@
 	}
 
 	// Current drop down button.
-	li[data-o-header-services-level] a[aria-current='true'] + .o-header-services__drop-down-button { // stylelint-disable-line selector-no-qualifying-type
+	.o-header-services__primary-nav li[data-o-header-services-level] a[aria-current='true'] + .o-header-services__drop-down-button { // stylelint-disable-line selector-no-qualifying-type
 		background-color: _oHeaderServicesGet('nav-hover-background');
 		&:hover {
 			background-color: _oHeaderServicesGet('button-hover-color');
@@ -36,7 +36,7 @@
 	}
 
 	// Drop down list.
-	ul[data-o-header-services-level="2"] { // stylelint-disable-line selector-no-qualifying-type
+	.o-header-services__primary-nav ul[data-o-header-services-level="2"] { // stylelint-disable-line selector-no-qualifying-type
 		@include oTypographySans(-1);
 		background: _oHeaderServicesGet('nav-background');
 		border: 1px solid _oHeaderServicesGet('nav-border');
@@ -67,14 +67,14 @@
 	}
 
 	// Completely hide visually hidden elements untill the dropdown is open.
-	ul[data-o-header-services-level] .o-header-services__visually-hidden { // stylelint-disable-line selector-no-qualifying-type
+	.o-header-services__primary-nav ul[data-o-header-services-level] .o-header-services__visually-hidden { // stylelint-disable-line selector-no-qualifying-type
 		display: none;
 	}
 
 	// Drop down list (opened state).
 	// stylelint-disable-next-line selector-no-qualifying-type
-	.core li[data-o-header-services-level]:hover,
-	li[aria-expanded=true] { // stylelint-disable-line selector-no-qualifying-type
+	.core .o-header-services__primary-nav li[data-o-header-services-level]:hover,
+	.o-header-services__primary-nav li[aria-expanded=true] { // stylelint-disable-line selector-no-qualifying-type
 		// Reveal the dropdown.
 		ul[data-o-header-services-level] { // stylelint-disable-line selector-no-qualifying-type
 			height: auto;
@@ -91,6 +91,11 @@
 			display: initial;
 		}
 
+		// Hide the bottom border which will clash with the top
+		// border of the dropdown list.
+		.o-header-services__drop-down-button { // stylelint-disable-line selector-no-qualifying-type
+			border-bottom-color: transparent;
+		}
 		// Update the dropdown icon to show the drawer is open.
 		.o-header-services__drop-down-button:after { // stylelint-disable-line selector-no-qualifying-type
 			transform: rotate(-180deg);


### PR DESCRIPTION
Fixes: https://github.com/Financial-Times/o-header-services/issues/150

<img width="708" alt="Screenshot 2020-08-12 at 16 59 42" src="https://user-images.githubusercontent.com/10405691/90038413-4e5f0080-dcbd-11ea-93d5-78c61db94486.png">
<img width="708" alt="Screenshot 2020-08-12 at 17 00 05" src="https://user-images.githubusercontent.com/10405691/90038417-4f902d80-dcbd-11ea-87e5-11e68fd07477.png">
<img width="562" alt="Screenshot 2020-08-12 at 17 01 35" src="https://user-images.githubusercontent.com/10405691/90038583-823a2600-dcbd-11ea-9b14-862315536af9.png">
