### PR TITLE
Hide focusable elements in collapsed dropdown menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This header is for tools and services built by the Financial Times.
 - [Markup](#markup)
 	- [Title Section](#title-section)
 	- [Primary navigation](#primary-navigation)
+	- [Core experience of the drawer](#core-experience-of-the-drawer)
 	- [Primary navigation with drop down](#primary-navigation-with-drop-down)
 	- [Secondary navigation](#secondary-navigation)
 	- [Themes](#themes)

--- a/demos/src/main.js
+++ b/demos/src/main.js
@@ -1,6 +1,1 @@
 import '../../main.js';
-
-document.addEventListener("DOMContentLoaded", function() {
-	document.documentElement.className = document.documentElement.className.replace('core', 'enhanced');
-	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
-});

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -1,1 +1,0 @@
-{{> secondary-navigation}}

--- a/origami.json
+++ b/origami.json
@@ -96,7 +96,12 @@
 		{
 			"title": "Pa11y",
 			"name": "pa11y",
-			"template": "demos/src/pa11y.mustache",
+			"template": "demos/src/header.mustache",
+			"data": {
+				"primary-navigation": true,
+				"drop-down": true,
+				"sub-navigation": true
+			},
 			"hidden": true,
 			"description": "Accessibility test will be run against this demo"
 		}

--- a/origami.json
+++ b/origami.json
@@ -29,7 +29,6 @@
 			"o-fonts@^4.0.0",
 			"o-normalise@^2.0.0"
 		],
-		"documentClasses": "core",
 		"sass": "demos/src/main.scss",
 		"template": "demos/src/header.mustache",
 		"js": "demos/src/main.js"

--- a/src/js/drawer.js
+++ b/src/js/drawer.js
@@ -67,22 +67,23 @@ class Drawer {
 
 	/**
 	 * Event Handler
-	 * @param {Object} event - The revent emitted by element/window interactions
+	 * @param {Object} event - The event emitted by element/window interactions
+	 * @return {void}
 	 */
-	handleEvent(e) {
-		if (e.type === 'resize') {
+	handleEvent(event) {
+		if (event.type === 'resize') {
 			this.debouncedRender();
 		}
 
-		if (e.type === 'keydown' && this.burger) {
-			if (e.key === 'Escape' && this.nav.classList.contains(this.class.open)) {
+		if (event.type === 'keydown' && this.burger) {
+			if (event.key === 'Escape' && this.nav.classList.contains(this.class.open)) {
 				this.toggleDrawer();
 				this.burger.focus();
 			}
 		}
 
-		if (e.type === 'click' && this.burger && [this.nav, this.burger, this.drawerCloseButton].includes(e.target)) {
-			e.preventDefault();
+		if (event.type === 'click' && this.burger && [this.nav, this.burger, this.drawerCloseButton].includes(event.target)) {
+			event.preventDefault();
 			this.toggleDrawer();
 		}
 	}
@@ -97,6 +98,7 @@ class Drawer {
 
 	/**
 	 * Drawer rendering
+	 * @return {void}
 	 */
 	render () {
 		if (this.enabled) {
@@ -105,7 +107,15 @@ class Drawer {
 			this.nav.removeEventListener('click', this);
 		}
 
-		this._shiftRelatedContentList(this.enabled);
+		// Shift related content (sign in, etc) between drawer and header title section
+		if (this.relatedContent && this.enabled) {
+			this.navList.appendChild(this.relatedContent);
+		}
+		if (this.relatedContent && !this.enabled) {
+			const headerTop = this.headerEl.querySelector('.o-header-services__top');
+			headerTop.appendChild(this.relatedContent);
+		}
+
 		this.nav.classList.toggle(this.class.drawer, this.enabled);
 
 		this.nav.setAttribute('aria-hidden', this.enabled);
@@ -113,6 +123,7 @@ class Drawer {
 
 	/**
 	 * Drawer hide/show functionality
+	 * @return {void}
 	 */
 	toggleDrawer () {
 		this.nav.classList.toggle(this.class.open);
@@ -127,19 +138,6 @@ class Drawer {
 				this.drawerCloseButton.focus();
 			}.bind(this), 50); // Wait for drawer to be open
 		}
-	}
-
-	/**
-	 * Shift related content (sign in, etc) between drawer and header title section
-	 */
-	_shiftRelatedContentList (shiftItems) {
-		const relatedContent = this.relatedContent;
-
-		if (!relatedContent) { return; }
-
-		const headerTop = this.headerEl.querySelector('.o-header-services__top');
-
-		return shiftItems ? this.navList.appendChild(relatedContent) : headerTop.appendChild(relatedContent);
 	}
 }
 

--- a/src/js/drop-down.js
+++ b/src/js/drop-down.js
@@ -41,17 +41,18 @@ class DropDown {
 
 	/**
 	 * Event Handler
-	 * @param {Object} event - The revent emitted by element/window interactions
+	 * @param {Object} event - The event emitted by element/window interactions
+	 * @return {void}
 	 */
-	handleEvent(e) {
-		if (e.type === 'click') {
-			if (!e.target.parentNode || !e.target.parentNode.getAttribute('data-o-header-services-level')) {
+	handleEvent(event) {
+		if (event.type === 'click') {
+			if (!event.target.parentNode || !event.target.parentNode.getAttribute('data-o-header-services-level')) {
 				this.reset();
 				return;
 			}
 
-			const target = e.target.closest('li');
-			if (!DropDown.isExpanded(target) && e.target.type === 'button') {
+			const target = event.target.closest('li');
+			if (!DropDown.isExpanded(target) && event.target.type === 'button') {
 				if (!this.isDrawer()) {
 					DropDown.collapseAll(this.navItems);
 				}
@@ -60,10 +61,10 @@ class DropDown {
 				DropDown.collapse(target);
 			}
 
-			e.stopPropagation();
+			event.stopPropagation();
 		}
 
-		if (e.key === 'Escape') {
+		if (event.key === 'Escape') {
 			this.reset();
 		}
 	}
@@ -71,6 +72,7 @@ class DropDown {
 	/**
 	 * Checks if primary nav is in a drawer
 	 * This boolean will change the drop down behaviour.
+	 * @return {boolean} - whether the drawer is enabled or not
 	 */
 	isDrawer() {
 		return this.drawer && this.drawer.enabled;
@@ -80,6 +82,7 @@ class DropDown {
 	 * Returns nav items to their original collapsed state,
 	 * items which contain links with the attribute `aria-current`
 	 * set to true remain expanded.
+	 * @return {void}
 	 */
 	reset() {
 		// Disable transitions immediately. These should only happen on user
@@ -102,6 +105,8 @@ class DropDown {
 
 	/**
 	 * Checks whether nav menu is expanded
+	 * @param {HTMLElement} item - the nav menu
+	 * @return {boolean} - whether the nav menu is expanded
 	 */
 	static isExpanded(item) {
 		return item.getAttribute('aria-expanded') === 'true';
@@ -109,6 +114,8 @@ class DropDown {
 
 	/**
 	 * Expands closed nav menu
+	 * @param {HTMLElement} item - the nav menu
+	 * @return {void}
 	 */
 	static expand(item) {
 		const childList = item.querySelector('ul');
@@ -123,6 +130,8 @@ class DropDown {
 
 	/**
 	 * Changes nav menu position relative to the window
+	 * @param {HTMLElement} item - the nav menu
+	 * @return {void}
 	 */
 	static position(item) {
 		if (item.getBoundingClientRect().right > window.innerWidth) {
@@ -132,6 +141,8 @@ class DropDown {
 
 	/**
 	 * Collapses open nav menu
+	 * @param {HTMLElement} item - the nav menu
+	 * @return {void}
 	 */
 	static collapse(item) {
 		const childList = item.querySelector('ul');
@@ -141,6 +152,8 @@ class DropDown {
 
 	/**
 	 * Collapses all open nav menus
+	 * @param {Array<HTMLElement>} items - the menu items to collapse
+	 * @return {void}
 	 */
 	static collapseAll(items) {
 		items.forEach(DropDown.collapse);
@@ -148,6 +161,8 @@ class DropDown {
 
 	/**
 	 * Expands all open nav menus
+	 * @param {Array<HTMLElement>} items - the menu items to expand
+	 * @return {void}
 	 */
 	static expandAll(items) {
 		items.forEach(DropDown.expand);
@@ -156,6 +171,8 @@ class DropDown {
 	/**
 	 * Returns items which contain an anchor
 	 * with the attribute `aria-current` set to true or "page".
+	 * @param {Array<HTMLElement>} items - the menu items to check
+	 * @return {HTMLElement} - The current menu item
 	 */
 	static getCurrent(items) {
 		return items.filter(item => {

--- a/src/js/drop-down.js
+++ b/src/js/drop-down.js
@@ -112,9 +112,13 @@ class DropDown {
 	 */
 	static expand(item) {
 		const childList = item.querySelector('ul');
-		item.setAttribute('aria-expanded', true);
-		childList.setAttribute('aria-hidden', false);
-		DropDown.position(childList);
+		requestAnimationFrame(() => {
+			childList.setAttribute('aria-hidden', false);
+			DropDown.position(childList);
+			requestAnimationFrame(() => {
+				item.setAttribute('aria-expanded', true);
+			});
+		});
 	}
 
 	/**

--- a/src/js/header.js
+++ b/src/js/header.js
@@ -18,18 +18,19 @@ class HeaderServices {
 	 * Initialise header component
 	 * @param {(HTMLElement|String)} rootElement - The root element to intialise the component in, or a CSS selector for the root element
 	 * @param {Object} [options={}] - An options object for configuring the component
+	 * @return {Array<HTMLElement>|HTMLElement} - The header(s) initalised.
 	 */
-	static init (rootEl, opts) {
-		if (!rootEl) {
-			rootEl = document.body;
+	static init (rootElement, options) {
+		if (!rootElement) {
+			rootElement = document.body;
 		}
-		if (!(rootEl instanceof HTMLElement)) {
-			rootEl = document.querySelector(rootEl);
+		if (!(rootElement instanceof HTMLElement)) {
+			rootElement = document.querySelector(rootElement);
 		}
-		if (rootEl instanceof HTMLElement && rootEl.matches('[data-o-component=o-header-services]')) {
-			return new HeaderServices(rootEl, opts);
+		if (rootElement instanceof HTMLElement && rootElement.matches('[data-o-component=o-header-services]')) {
+			return new HeaderServices(rootElement, options);
 		}
-		return Array.from(rootEl.querySelectorAll('[data-o-component="o-header-services"]'), rootEl => new HeaderServices(rootEl, opts));
+		return Array.from(rootElement.querySelectorAll('[data-o-component="o-header-services"]'), rootElement => new HeaderServices(rootElement, options));
 	}
 }
 

--- a/src/js/header.js
+++ b/src/js/header.js
@@ -11,6 +11,7 @@ class HeaderServices {
 		const drawer = new Drawer(headerEl);
 		new DropDown(headerEl, drawer);
 		new Scroll(headerEl);
+		headerEl.setAttribute('data-o-header-services-js', true);
 	}
 
 	/**

--- a/src/js/scroll.js
+++ b/src/js/scroll.js
@@ -27,6 +27,7 @@ class Scroll {
 
 	/**
 	 * Scroll functionality rendering
+	 * @return {void}
 	 */
 	render () {
 		this.showCurrentSelection();
@@ -35,6 +36,7 @@ class Scroll {
 
 	/**
 	 * Hide/show scroll buttons
+	 * @return {void}
 	 */
 	toggleScrollButtons () {
 		this._getWidths();
@@ -50,11 +52,14 @@ class Scroll {
 
 	/**
 	 * Scrolling functionality
+	 * @param {Object} event - A scroll event
+	 * @return {void}
 	 */
-	scroll (e) {
+	scroll(event) {
+		const target = event.currentTarget;
 		let distance = 100;
 
-		if(e.currentTarget.className.match('left')) {
+		if (target.className.match('left')) {
 			distance = (this.list.scrollLeft > distance ? distance : this.list.scrollLeft) * -1;
 		} else {
 			const remaining = this._remaining();
@@ -77,6 +82,7 @@ class Scroll {
 
 	/**
 	 * Scroll secondary nav to 'current selection'
+	 * @return {void}
 	 */
 	showCurrentSelection () {
 		this._getWidths();

--- a/src/scss/_drop-down.scss
+++ b/src/scss/_drop-down.scss
@@ -78,7 +78,7 @@
 		// Reveal the dropdown.
 		ul[data-o-header-services-level] { // stylelint-disable-line selector-no-qualifying-type
 			height: auto;
-			@supports (pointer-events: none) {
+			@supports (pointer-events: none) { // stylelint-disable-line selector-no-qualifying-type
 				pointer-events: all;
 			}
 			transform: translateY(0);
@@ -87,7 +87,7 @@
 		}
 
 		// Reveal visually hidden elements within the dropdown to screen readers.
-		ul[data-o-header-services-level]{ // stylelint-disable-line selector-no-qualifying-type
+		ul[data-o-header-services-level] { // stylelint-disable-line selector-no-qualifying-type
 			display: block;
 		}
 

--- a/src/scss/_drop-down.scss
+++ b/src/scss/_drop-down.scss
@@ -66,8 +66,8 @@
 		}
 	}
 
-	// Completely hide visually hidden elements untill the dropdown is open.
-	.o-header-services__primary-nav ul[data-o-header-services-level] .o-header-services__visually-hidden { // stylelint-disable-line selector-no-qualifying-type
+	// Completely hide visually hidden elements until the dropdown is open.
+	.o-header-services__primary-nav ul[data-o-header-services-level="2"][aria-hidden=true] { // stylelint-disable-line selector-no-qualifying-type
 		display: none;
 	}
 
@@ -87,8 +87,8 @@
 		}
 
 		// Reveal visually hidden elements within the dropdown to screen readers.
-		ul[data-o-header-services-level] .o-header-services__visually-hidden { // stylelint-disable-line selector-no-qualifying-type
-			display: initial;
+		ul[data-o-header-services-level]{ // stylelint-disable-line selector-no-qualifying-type
+			display: block;
 		}
 
 		// Hide the bottom border which will clash with the top

--- a/src/scss/_drop-down.scss
+++ b/src/scss/_drop-down.scss
@@ -87,9 +87,10 @@
 		}
 
 		// Reveal visually hidden elements within the dropdown to screen readers.
-		ul[data-o-header-services-level] { // stylelint-disable-line selector-no-qualifying-type
+		// stylelint-disable-next-line selector-no-qualifying-type
+		ul[data-o-header-services-level] {
 			display: block;
-		}
+		}  // stylelint-disable-line selector-no-qualifying-type
 
 		// Hide the bottom border which will clash with the top
 		// border of the dropdown list.

--- a/src/scss/_drop-down.scss
+++ b/src/scss/_drop-down.scss
@@ -73,7 +73,7 @@
 
 	// Drop down list (opened state).
 	// stylelint-disable-next-line selector-no-qualifying-type
-	.core .o-header-services__primary-nav li[data-o-header-services-level]:hover,
+	.o-header-services:not([data-o-header-services-js]) .o-header-services__primary-nav li[data-o-header-services-level]:hover,
 	.o-header-services__primary-nav li[aria-expanded=true] { // stylelint-disable-line selector-no-qualifying-type
 		// Reveal the dropdown.
 		ul[data-o-header-services-level] { // stylelint-disable-line selector-no-qualifying-type

--- a/src/scss/_primary-nav.scss
+++ b/src/scss/_primary-nav.scss
@@ -39,6 +39,9 @@
 			padding: $_o-header-services-padding if(_oHeaderServicesGet('primary-nav-item-horizontal-padding'), _oHeaderServicesGet('primary-nav-item-horizontal-padding'), oSpacingByIncrement(5));
 			text-transform: uppercase;
 			box-sizing: border-box;
+			&:focus {
+				outline-offset: -2px;
+			}
 
 			&:hover {
 				color: _oHeaderServicesGet('text-hover-color');

--- a/src/scss/_secondary-nav.scss
+++ b/src/scss/_secondary-nav.scss
@@ -124,7 +124,7 @@
 		}
 	}
 
-	.core .o-header-services__scroll-button {
+	.o-header-services:not([data-o-header-services-js]) .o-header-services__scroll-button {
 		display: none;
 	}
 

--- a/test/js/drop-down.test.js
+++ b/test/js/drop-down.test.js
@@ -27,10 +27,13 @@ describe('Dropdown', () => {
 	});
 
 	describe('toggles drop down menu via `aria-expanded`', () => {
-		it('open on click', () => {
+		it('open on click', (done) => {
 			click(navItems[0], 'button');
-			attribute = navItems[0].getAttribute('aria-expanded') === 'true';
-			proclaim.isTrue(attribute);
+			setTimeout(() => {
+				attribute = navItems[0].getAttribute('aria-expanded') === 'true';
+				proclaim.isTrue(attribute);
+				done();
+			}, 100);
 		});
 
 		it('hides on double click', () => {
@@ -40,15 +43,20 @@ describe('Dropdown', () => {
 			proclaim.isTrue(attribute);
 		});
 
-		it('hides open dropdowns when different nav item is toggled', () => {
+		it('hides open dropdowns when different nav item is toggled', (done) => {
 			click(navItems[0], 'button');
-			attribute = navItems[0].getAttribute('aria-expanded') === 'true';
-			proclaim.isTrue(attribute);
-			click(navItems[1], 'button');
-			attribute = navItems[0].getAttribute('aria-expanded') === 'false';
-			proclaim.isTrue(attribute);
-			attribute = navItems[1].getAttribute('aria-expanded') === 'true';
-			proclaim.isTrue(attribute);
+			setTimeout(() => {
+				attribute = navItems[0].getAttribute('aria-expanded') === 'true';
+				proclaim.isTrue(attribute);
+				click(navItems[1], 'button');
+				setTimeout(() => {
+					attribute = navItems[0].getAttribute('aria-expanded') === 'false';
+					proclaim.isTrue(attribute);
+					attribute = navItems[1].getAttribute('aria-expanded') === 'true';
+					proclaim.isTrue(attribute);
+					done();
+				}, 100);
+			}, 100);
 		});
 
 		it('hides all menus if click outside of nav items', (done) => {

--- a/test/js/drop-down.test.js
+++ b/test/js/drop-down.test.js
@@ -31,8 +31,12 @@ describe('Dropdown', () => {
 			click(navItems[0], 'button');
 			setTimeout(() => {
 				attribute = navItems[0].getAttribute('aria-expanded') === 'true';
-				proclaim.isTrue(attribute);
-				done();
+				try {
+					proclaim.isTrue(attribute);
+					done();
+				} catch (error) {
+					done(error);
+				}
 			}, 100);
 		});
 
@@ -47,14 +51,23 @@ describe('Dropdown', () => {
 			click(navItems[0], 'button');
 			setTimeout(() => {
 				attribute = navItems[0].getAttribute('aria-expanded') === 'true';
-				proclaim.isTrue(attribute);
+				try {
+					proclaim.isTrue(attribute);
+				} catch (error) {
+					done(error);
+					return;
+				}
 				click(navItems[1], 'button');
 				setTimeout(() => {
-					attribute = navItems[0].getAttribute('aria-expanded') === 'false';
-					proclaim.isTrue(attribute);
-					attribute = navItems[1].getAttribute('aria-expanded') === 'true';
-					proclaim.isTrue(attribute);
-					done();
+					try {
+						attribute = navItems[0].getAttribute('aria-expanded') === 'false';
+						proclaim.isTrue(attribute);
+						attribute = navItems[1].getAttribute('aria-expanded') === 'true';
+						proclaim.isTrue(attribute);
+						done();
+					} catch (error) {
+						done(error);
+					}
 				}, 100);
 			}, 100);
 		});


### PR DESCRIPTION
- Hide focusable elements in collapsed dropdown menus (Fixes https://github.com/Financial-Times/o-header-services/issues/152)
- Include dropdowns in pa11y check (relates to https://github.com/Financial-Times/o-header-services/issues/152)
- Improve the focus state of dropdown nav items
- Update JSDoc/parameter names
- Replace use of document `core` class (the core/enhanced classes are not part of the spec and components
should work independently)