### PR TITLE
Fix the hidden close button in the drawer.

### DIFF
--- a/src/js/drop-down.js
+++ b/src/js/drop-down.js
@@ -63,7 +63,9 @@ class DropDown {
 			// support `Array.prototype.find()` or `Element.closest()`,
 			// adding a polyfill requirement is a breaking change
 			let parentMenu;
-			for (const navItem of this.navItems) {
+			for (let itemIndex = 0; itemIndex < this.navItems.length; itemIndex++) {
+				const navItem = this.navItems[itemIndex];
+
 				if (navItem.contains(event.target)) {
 					parentMenu = navItem;
 					break; // found the parent menu

--- a/src/js/drop-down.js
+++ b/src/js/drop-down.js
@@ -59,8 +59,17 @@ class DropDown {
 				return;
 			}
 
-			// Bail if there's no parent menu to toggle.
-			const parentMenu = event.target.closest('[data-o-header-services-level="1"]');
+			// Bail if there's no parent menu to toggle. Note: IE11 does not
+			// support `Array.prototype.find()` or `Element.closest()`,
+			// adding a polyfill requirement is a breaking change
+			let parentMenu;
+			for (const navItem of this.navItems) {
+				if (navItem.contains(event.target)) {
+					parentMenu = navItem;
+					break; // found the parent menu
+				}
+			}
+
 			if (!parentMenu) {
 				return;
 			}

--- a/src/js/drop-down.js
+++ b/src/js/drop-down.js
@@ -45,27 +45,37 @@ class DropDown {
 	 * @return {void}
 	 */
 	handleEvent(event) {
-		if (event.type === 'click') {
-			if (!event.target.parentNode || !event.target.parentNode.getAttribute('data-o-header-services-level')) {
+		if (event.key === 'Escape') {
+			this.reset();
+		}
+
+		if (event.type === 'click' && event.target) {
+			// Close dropdown if some non-nav element on the page is clicked.
+			if (event.target.nodeName !== 'BUTTON' &&
+				event.target.nodeName !== 'A' &&
+				event.target !== this.drawer.navList
+			) {
 				this.reset();
 				return;
 			}
 
-			const target = event.target.closest('li');
-			if (!DropDown.isExpanded(target) && event.target.type === 'button') {
+			// Bail if there's no parent menu to toggle.
+			const parentMenu = event.target.closest('[data-o-header-services-level="1"]');
+			if (!parentMenu) {
+				return;
+			}
+
+			// Toggle the menu. Close other open menus when not in the drawer.
+			if (!DropDown.isExpanded(parentMenu)) {
 				if (!this.isDrawer()) {
 					DropDown.collapseAll(this.navItems);
 				}
-				DropDown.expand(target);
+				DropDown.expand(parentMenu);
 			} else {
-				DropDown.collapse(target);
+				DropDown.collapse(parentMenu);
 			}
 
 			event.stopPropagation();
-		}
-
-		if (event.key === 'Escape') {
-			this.reset();
 		}
 	}
 

--- a/test/js/drop-down.test.js
+++ b/test/js/drop-down.test.js
@@ -47,6 +47,17 @@ describe('Dropdown', () => {
 			proclaim.isTrue(attribute);
 		});
 
+		it('hides when the hidden button at the end of a menu is clicked', () => {
+			// open with main button
+			const navItem = navItems[0];
+			click(navItem, 'button');
+			// close with button at end of menu
+			const navItemDropdown = navItem.querySelector('[data-o-header-services-level="2"]');
+			click(navItemDropdown, 'button');
+			attribute = navItem.getAttribute('aria-expanded') === 'false';
+			proclaim.isTrue(attribute);
+		});
+
 		it('hides open dropdowns when different nav item is toggled', (done) => {
 			click(navItems[0], 'button');
 			setTimeout(() => {


### PR DESCRIPTION
If the dropdown close button at the end of the dropdown menu
is clicked it will not close the menu if the menu has the current
page within it and the drawer is open.