### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import HeaderServices from './src/js/header';
+import HeaderServices from './src/js/header.js';
 
 const constructAll = () => {
 	HeaderServices.init();

--- a/src/js/header.js
+++ b/src/js/header.js
@@ -1,6 +1,6 @@
-import Drawer from './drawer';
-import DropDown from './drop-down';
-import Scroll from './scroll';
+import Drawer from './drawer.js';
+import DropDown from './drop-down.js';
+import Scroll from './scroll.js';
 
 class HeaderServices {
 	/**

--- a/test/js/drawer.test.js
+++ b/test/js/drawer.test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim */
 
-import HeaderServices from '../../src/js/header';
-import * as fixtures from '../helpers/fixtures';
+import HeaderServices from '../../src/js/header.js';
+import * as fixtures from '../helpers/fixtures.js';
 
 describe('Drawer', () => {
 	let headerEl;

--- a/test/js/drop-down.test.js
+++ b/test/js/drop-down.test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim */
 
-import HeaderServices from '../../src/js/header';
-import * as fixtures from '../helpers/fixtures';
+import HeaderServices from '../../src/js/header.js';
+import * as fixtures from '../helpers/fixtures.js';
 
 describe('Dropdown', () => {
 	let attribute;

--- a/test/js/header.test.js
+++ b/test/js/header.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim */
 
-import HeaderServices from '../../src/js/header';
+import HeaderServices from '../../src/js/header.js';
 
 describe('Header instance', () => {
 	let headerEl;


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing